### PR TITLE
Add Authelia SSO and Watchtower services

### DIFF
--- a/network/Makefile
+++ b/network/Makefile
@@ -4,7 +4,7 @@
 .PHONY: help deploy update restart status logs stop start clean setup env
 
 # Service definitions
-SERVICES := caddy pihole uptime-kuma homarr homer prometheus grafana ntfy authelia watchtower
+SERVICES := pihole authelia caddy uptime-kuma homarr homer prometheus grafana ntfy watchtower
 OPERATIONS := deploy update restart status logs stop start push save
 
 # Default target

--- a/network/Makefile
+++ b/network/Makefile
@@ -4,7 +4,7 @@
 .PHONY: help deploy update restart status logs stop start clean setup env
 
 # Service definitions
-SERVICES := caddy pihole uptime-kuma homarr homer prometheus grafana ntfy
+SERVICES := caddy pihole uptime-kuma homarr homer prometheus grafana ntfy authelia watchtower
 OPERATIONS := deploy update restart status logs stop start push save
 
 # Default target

--- a/network/authelia/.env.example
+++ b/network/authelia/.env.example
@@ -1,0 +1,4 @@
+### AUTHELIA ###
+AUTHELIA_JWT_SECRET=generate_with_openssl_rand_hex_64
+AUTHELIA_SESSION_SECRET=generate_with_openssl_rand_hex_64
+AUTHELIA_STORAGE_ENCRYPTION_KEY=generate_with_openssl_rand_hex_64

--- a/network/authelia/.gitignore
+++ b/network/authelia/.gitignore
@@ -1,4 +1,9 @@
 # Authelia data (SQLite DB, user database with hashed passwords)
+# NOTE: The data/ directory is intentionally not tracked by git.
+# Before deploying, you must:
+#   1) Create the data/ directory.
+#   2) Copy users_database.yml.example to data/users_database.yml.
+#   3) Generate a password hash and replace the example hash in data/users_database.yml.
 data/
 
 # Environment files

--- a/network/authelia/.gitignore
+++ b/network/authelia/.gitignore
@@ -1,0 +1,12 @@
+# Authelia data (SQLite DB, user database with hashed passwords)
+data/
+
+# Environment files
+.env
+.env.local
+.env.production
+
+# Temporary files
+*.tmp
+*.temp
+*.log

--- a/network/authelia/configuration.yml
+++ b/network/authelia/configuration.yml
@@ -1,0 +1,29 @@
+---
+# Authelia minimal configuration for mati-lab homelab
+# Docs: https://www.authelia.com/configuration/
+
+server:
+  address: 'tcp://:9091'
+
+log:
+  level: info
+
+authentication_backend:
+  file:
+    path: /config/data/users_database.yml
+
+session:
+  cookies:
+    - domain: 'mati-lab.online'
+      authelia_url: 'https://authelia.mati-lab.online'
+
+storage:
+  local:
+    path: /config/data/db.sqlite3
+
+access_control:
+  default_policy: one_factor
+
+notifier:
+  filesystem:
+    filename: /config/data/notification.txt

--- a/network/authelia/configuration.yml
+++ b/network/authelia/configuration.yml
@@ -23,6 +23,11 @@ storage:
 
 access_control:
   default_policy: one_factor
+  rules:
+    - domain: uptime-kuma.mati-lab.online
+      policy: bypass
+    - domain: ntfy.mati-lab.online
+      policy: bypass
 
 notifier:
   filesystem:

--- a/network/authelia/docker-compose.yml
+++ b/network/authelia/docker-compose.yml
@@ -1,0 +1,22 @@
+networks:
+  pihole-net:
+    external: true
+
+services:
+  authelia:
+    image: authelia/authelia:4.38
+    container_name: authelia
+    env_file:
+      - .env
+    volumes:
+      - ./configuration.yml:/config/configuration.yml
+      - ./data:/config/data
+    ports:
+      - 9091:9091
+    restart: unless-stopped
+
+    networks:
+      - pihole-net
+    labels:
+      - "com.docker.compose.project=authelia"
+      - "com.docker.compose.service=authelia"

--- a/network/authelia/users_database.yml.example
+++ b/network/authelia/users_database.yml.example
@@ -1,0 +1,14 @@
+---
+# Authelia users database
+# Generate password hash: docker run --rm authelia/authelia:4.38 crypto hash generate argon2
+#
+# Place this file at data/users_database.yml (not tracked by git)
+
+users:
+  admin:
+    displayname: "Admin"
+    # password: changeme (replace with argon2 hash from command above)
+    password: "$argon2id$v=19$m=65536,t=3,p=4$REPLACE_WITH_REAL_HASH"
+    email: admin@mati-lab.online
+    groups:
+      - admins

--- a/network/caddy/Caddyfile
+++ b/network/caddy/Caddyfile
@@ -12,9 +12,13 @@
 
     @pihole host pihole.mati-lab.online
     handle @pihole {
+        forward_auth http://authelia:9091 {
+            uri /api/authz/forward-auth
+            copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+        }
         @pihole_root path /
         redir @pihole_root /admin 301
-        
+
         reverse_proxy http://pihole:8080 {
             header_up Host {host}
             header_up X-Forwarded-Proto https
@@ -24,6 +28,10 @@
 
     @proxmox host proxmox.mati-lab.online
     handle @proxmox {
+        forward_auth http://authelia:9091 {
+            uri /api/authz/forward-auth
+            copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+        }
         reverse_proxy 192.168.1.11:8006 {
             transport http {
                 tls_insecure_skip_verify
@@ -33,6 +41,10 @@
 
     @homebridge host homebridge.mati-lab.online
     handle @homebridge {
+        forward_auth http://authelia:9091 {
+            uri /api/authz/forward-auth
+            copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+        }
         reverse_proxy 192.168.1.155 {
             header_up Host {host}
             header_up X-Forwarded-Proto https
@@ -53,6 +65,10 @@
 
     @homarr host homarr.mati-lab.online
     handle @homarr {
+        forward_auth http://authelia:9091 {
+            uri /api/authz/forward-auth
+            copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+        }
         reverse_proxy http://homarr:7575 {
             header_up Host {host}
             header_up X-Forwarded-Proto https
@@ -62,6 +78,10 @@
 
     @homer host homer.mati-lab.online
     handle @homer {
+        forward_auth http://authelia:9091 {
+            uri /api/authz/forward-auth
+            copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+        }
         reverse_proxy http://homer:6565 {
             header_up Host {host}
             header_up X-Forwarded-Proto https
@@ -71,6 +91,10 @@
 
     @prometheus host prometheus.mati-lab.online
     handle @prometheus {
+        forward_auth http://authelia:9091 {
+            uri /api/authz/forward-auth
+            copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+        }
         reverse_proxy http://prometheus:9090 {
             header_up Host {host}
             header_up X-Forwarded-Proto https
@@ -80,6 +104,10 @@
 
     @grafana host grafana.mati-lab.online
     handle @grafana {
+        forward_auth http://authelia:9091 {
+            uri /api/authz/forward-auth
+            copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+        }
         reverse_proxy http://grafana:3000 {
             header_up Host {host}
             header_up X-Forwarded-Proto https

--- a/network/caddy/Caddyfile
+++ b/network/caddy/Caddyfile
@@ -96,6 +96,15 @@
         }
     }
 
+    @authelia host authelia.mati-lab.online
+    handle @authelia {
+        reverse_proxy http://authelia:9091 {
+            header_up Host {host}
+            header_up X-Forwarded-Proto https
+            header_up X-Forwarded-Ssl on
+        }
+    }
+
     handle {
         respond "unknown host" 404
     }

--- a/network/scripts/manage-all.sh
+++ b/network/scripts/manage-all.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Available services
-SERVICES=(pihole caddy uptime-kuma homarr prometheus grafana)
+SERVICES=(pihole caddy uptime-kuma homarr homer prometheus grafana ntfy authelia watchtower)
 
 log_success(){ printf "\033[0;32m[SUCCESS]\033[0m %s\n" "$*"; }
 log_warning(){ printf "\033[1;33m[WARNING]\033[0m %s\n" "$*"; }

--- a/network/scripts/manage-all.sh
+++ b/network/scripts/manage-all.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Available services
-SERVICES=(pihole caddy uptime-kuma homarr homer prometheus grafana ntfy authelia watchtower)
+SERVICES=(pihole authelia caddy uptime-kuma homarr homer prometheus grafana ntfy watchtower)
 
 log_success(){ printf "\033[0;32m[SUCCESS]\033[0m %s\n" "$*"; }
 log_warning(){ printf "\033[1;33m[WARNING]\033[0m %s\n" "$*"; }

--- a/network/scripts/manage-authelia.sh
+++ b/network/scripts/manage-authelia.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SERVICE_NAME="authelia"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# save = push (config is on host)
+save() { log "Pushing authelia config to GitHub"; push; }
+
+# Handle command line arguments
+case "${1:-help}" in
+  deploy|update|restart|start|stop|status|logs|push|save) "$1" ;;
+  *) echo "usage: $0 {deploy|update|restart|start|stop|status|logs|push|save}"; exit 1 ;;
+esac

--- a/network/scripts/manage-watchtower.sh
+++ b/network/scripts/manage-watchtower.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SERVICE_NAME="watchtower"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# save = push (no extra config to save)
+save() { log "Pushing watchtower config to GitHub"; push; }
+
+# Handle command line arguments
+case "${1:-help}" in
+  deploy|update|restart|start|stop|status|logs|push|save) "$1" ;;
+  *) echo "usage: $0 {deploy|update|restart|start|stop|status|logs|push|save}"; exit 1 ;;
+esac

--- a/network/watchtower/.env.example
+++ b/network/watchtower/.env.example
@@ -1,0 +1,2 @@
+### WATCHTOWER ###
+WATCHTOWER_NOTIFICATION_URL=shoutrrr://ntfy/watchtower?host=https://ntfy.mati-lab.online

--- a/network/watchtower/.gitignore
+++ b/network/watchtower/.gitignore
@@ -1,0 +1,9 @@
+# Environment files
+.env
+.env.local
+.env.production
+
+# Temporary files
+*.tmp
+*.temp
+*.log

--- a/network/watchtower/docker-compose.yml
+++ b/network/watchtower/docker-compose.yml
@@ -1,0 +1,23 @@
+networks:
+  pihole-net:
+    external: true
+
+services:
+  watchtower:
+    image: containrrr/watchtower:latest
+    container_name: watchtower
+    env_file:
+      - .env
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      WATCHTOWER_MONITOR_ONLY: "true"
+      WATCHTOWER_CLEANUP: "false"
+      WATCHTOWER_POLL_INTERVAL: "86400"
+    restart: unless-stopped
+
+    networks:
+      - pihole-net
+    labels:
+      - "com.docker.compose.project=watchtower"
+      - "com.docker.compose.service=watchtower"


### PR DESCRIPTION
## Summary
- **Authelia** — SSO/auth proxy with file-based users, SQLite storage, and Caddy `forward_auth` integration. Protects pihole, proxmox, homebridge, homarr, homer, prometheus, and grafana. Uptime-kuma and ntfy remain open.
- **Watchtower** — Container update monitor (monitor-only mode) with ntfy notifications via shoutrrr.
- Management scripts, Makefile targets, and `manage-all.sh` updated for both services. Also adds missing `homer` and `ntfy` to `manage-all.sh`.

## Test plan
- [ ] Generate secrets and create `.env` files from `.env.example` templates
- [ ] Create `data/users_database.yml` from example with real argon2 hash
- [ ] Deploy Authelia and verify login portal at `authelia.mati-lab.online`
- [ ] Verify protected services redirect to Authelia login
- [ ] Verify uptime-kuma and ntfy remain accessible without auth
- [ ] Deploy Watchtower and verify ntfy notifications for available updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)