### PR TITLE
Add users database scp to Authelia deploy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @gOOrcio
+.github/workflows/ @gOOrcio
+infra/ @gOOrcio

--- a/network/scripts/manage-authelia.sh
+++ b/network/scripts/manage-authelia.sh
@@ -5,6 +5,26 @@ SERVICE_NAME="authelia"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
+SERVICE_DIR="../$SERVICE_NAME"
+REMOTE_DATA="/opt/mati-lab/network/$SERVICE_NAME/data"
+
+# Copy data/ files (users_database.yml) that are gitignored
+copy_data() {
+  if [[ -f "${SERVICE_DIR}/data/users_database.yml" ]]; then
+    log "Copying users database to server..."
+    ssh "${SSH_OPTS[@]}" "$REMOTE" "mkdir -p $REMOTE_DATA"
+    scp "${SSH_OPTS[@]}" "${SERVICE_DIR}/data/users_database.yml" "$REMOTE:$REMOTE_DATA/"
+  else
+    log_error "No users database found at ${SERVICE_DIR}/data/users_database.yml"
+    log_error "Copy users_database.yml.example to data/users_database.yml and set a real password hash"
+    return 1
+  fi
+}
+
+# Override deploy/update to also push data files
+deploy() { log "Deploying $SERVICE_NAME"; sync_from_github; copy_env_file "$SERVICE_DIR"; copy_data; compose_cmd up -d --pull always; }
+update() { log "Updating $SERVICE_NAME"; sync_from_github; copy_env_file "$SERVICE_DIR"; copy_data; compose_cmd down; compose_cmd up -d --pull always; }
+
 # save = push (config is on host)
 save() { log "Pushing authelia config to GitHub"; push; }
 


### PR DESCRIPTION
## Summary
- Authelia's `data/users_database.yml` is gitignored (contains hashed passwords), so deploy/update now scp it to the server alongside `.env`
- Deploy fails early with a clear error if the file is missing locally

## Test plan
- [ ] Verify `make deploy-authelia` copies `data/users_database.yml` to server
- [ ] Verify deploy fails with helpful message when file is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)