### PR TITLE
feat(smart-resume): run tests before deployment

### DIFF
--- a/compute/smart_resume_vm/playbooks/deploy_app.yml
+++ b/compute/smart_resume_vm/playbooks/deploy_app.yml
@@ -3,6 +3,22 @@
   vars_files:
     - ../group_vars/all/vars.yml
     - ../group_vars/all/vault.yml
+
+  pre_tasks:
+    - name: Run API tests (pytest)
+      ansible.builtin.command:
+        cmd: uv run pytest tests/ -q --tb=short
+        chdir: "{{ app_repo_path }}/apps/api"
+      delegate_to: localhost
+      run_once: true
+
+    - name: Run frontend E2E tests (Playwright)
+      ansible.builtin.command:
+        cmd: yarn test:e2e --timeout=30000
+        chdir: "{{ app_repo_path }}/apps/web"
+      delegate_to: localhost
+      run_once: true
+
   tasks:
     - name: Create app directory
       ansible.builtin.file:

--- a/compute/smart_resume_vm/playbooks/deploy_app.yml
+++ b/compute/smart_resume_vm/playbooks/deploy_app.yml
@@ -1,5 +1,6 @@
 - name: Deploy application
   hosts: smart-resume
+  gather_facts: false
   vars_files:
     - ../group_vars/all/vars.yml
     - ../group_vars/all/vault.yml
@@ -11,6 +12,7 @@
         chdir: "{{ app_repo_path }}/apps/api"
       delegate_to: localhost
       run_once: true
+      changed_when: false
 
     - name: Run frontend E2E tests (Playwright)
       ansible.builtin.command:
@@ -18,6 +20,7 @@
         chdir: "{{ app_repo_path }}/apps/web"
       delegate_to: localhost
       run_once: true
+      changed_when: false
 
   tasks:
     - name: Create app directory


### PR DESCRIPTION
Add pre_tasks to deploy_app.yml that run locally (delegate_to: localhost) before syncing code to the VM:
  1. API tests: uv run pytest tests/ -q --tb=short
  2. E2E tests: yarn test:e2e --timeout=30000 (starts Astro dev server)

Both tasks fail-fast on non-zero exit, blocking the deployment if any test fails. Uses app_repo_path var already defined in vars.yml.