### PR TITLE
feat: add ollama_vm Ansible playbooks + update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Personal homelab configuration running on a Proxmox host with a Raspberry Pi as 
 
 | VM | ID | IP | Purpose |
 |----|----|----|---------|
-| ollama-gpu | 101 | — | Local LLM inference |
+| ollama-gpu | 101 | 192.168.1.48 | Local LLM inference (RTX 3070, GPU passthrough) |
 | smart-resume | 102 | 192.168.1.200 | Personal AI-powered CV app |
 | sonarqube | 103 | 192.168.1.201 | Code quality platform (SonarQube CE + community-branch-plugin) |
 

--- a/compute/ollama_vm/.gitignore
+++ b/compute/ollama_vm/.gitignore
@@ -1,0 +1,2 @@
+group_vars/all/vault.yml
+group_vars/all/vault.yml.plain

--- a/compute/ollama_vm/Makefile
+++ b/compute/ollama_vm/Makefile
@@ -1,0 +1,13 @@
+.PHONY: provision configure deploy install-deps
+
+install-deps:
+	ansible-galaxy collection install -r requirements.yml
+
+provision: install-deps
+	ansible-playbook playbooks/site.yml
+
+configure:
+	ansible-playbook playbooks/configure_vm.yml
+
+deploy:
+	ansible-playbook playbooks/deploy_app.yml

--- a/compute/ollama_vm/ansible.cfg
+++ b/compute/ollama_vm/ansible.cfg
@@ -1,0 +1,7 @@
+[defaults]
+inventory          = inventory/hosts.yml
+roles_path         = roles
+vault_password_file = ~/.vault_pass
+host_key_checking  = False
+stdout_callback    = default
+result_format      = yaml

--- a/compute/ollama_vm/group_vars/all/vars.yml
+++ b/compute/ollama_vm/group_vars/all/vars.yml
@@ -1,0 +1,48 @@
+# Proxmox connection
+proxmox_host: "192.168.1.184"
+proxmox_node: "proxmox"
+proxmox_api_user: "root@pam"
+proxmox_api_token_id:     "{{ vault_proxmox_api_token_id }}"
+proxmox_api_token_secret: "{{ vault_proxmox_api_token_secret }}"
+
+# VM spec
+vm_id: 101
+vm_name: "ollama-gpu"
+# NOTE: create_vm.yml requires an Ubuntu 24.04 cloud-init template.
+# Template 9000 is Debian 12 — create a separate Ubuntu 24.04 template and set its ID here.
+# See: https://cloudinit.readthedocs.io/en/latest/ for how to create one in Proxmox.
+vm_template_id: 9001
+vm_cores: 4
+vm_memory_mb: 12288
+vm_disk_size: "128G"
+vm_storage: "local-lvm"
+
+# GPU passthrough (PCIe)
+# Get the PCI address from Proxmox shell: lspci | grep -i nvidia
+vm_gpu_pcie: "0000:26:00"
+
+# Network (static)
+vm_ip: "192.168.1.48"
+vm_gateway: "192.168.1.1"
+vm_nameserver: "192.168.1.1"
+vm_cidr: 24
+
+# SSH
+vm_ssh_user: "ollama-gpu"
+vm_ssh_key_path: "~/.ssh/id_ed25519.pub"
+
+# Nvidia driver — open kernel module variant, pinned to Ubuntu 24.04 package
+nvidia_driver_package: "nvidia-driver-590-open"
+
+# Ollama
+ollama_version: "0.17.5"
+ollama_host: "0.0.0.0:11434"
+
+# Models to pull — pulled in order, large models last
+# smart-resume requires: qwen2.5:7b-instruct, nomic-embed-text
+ollama_models:
+  - "nomic-embed-text:latest"
+  - "qwen2.5:7b-instruct"
+  - "qwen3.5:2b"
+  - "qwen3.5:4b"
+  - "qwen3.5:9b"

--- a/compute/ollama_vm/group_vars/all/vars.yml
+++ b/compute/ollama_vm/group_vars/all/vars.yml
@@ -8,10 +8,10 @@ proxmox_api_token_secret: "{{ vault_proxmox_api_token_secret }}"
 # VM spec
 vm_id: 101
 vm_name: "ollama-gpu"
-# NOTE: create_vm.yml requires an Ubuntu 24.04 cloud-init template.
-# Template 9000 is Debian 12 — create a separate Ubuntu 24.04 template and set its ID here.
-# See: https://cloudinit.readthedocs.io/en/latest/ for how to create one in Proxmox.
-vm_template_id: 9001
+# Ubuntu 24.04 cloud-init template with Nvidia drivers + Ollama pre-installed.
+# To re-create this template: clone VM 101, generalize (clear machine-id, SSH host keys),
+# shut down, and convert to template.
+vm_template_id: 100
 vm_cores: 4
 vm_memory_mb: 12288
 vm_disk_size: "128G"

--- a/compute/ollama_vm/inventory/hosts.yml
+++ b/compute/ollama_vm/inventory/hosts.yml
@@ -1,0 +1,7 @@
+all:
+  hosts:
+    ollama-gpu:
+      ansible_host: "192.168.1.48"
+      ansible_user: ollama-gpu
+      ansible_ssh_private_key_file: ~/.ssh/id_ed25519
+      ansible_python_interpreter: /usr/bin/python3

--- a/compute/ollama_vm/playbooks/configure_vm.yml
+++ b/compute/ollama_vm/playbooks/configure_vm.yml
@@ -1,0 +1,58 @@
+- name: Configure VM
+  hosts: ollama-gpu
+  become: true
+  vars_files:
+    - ../group_vars/all/vars.yml
+    - ../group_vars/all/vault.yml
+  tasks:
+    - name: Wait for cloud-init to finish
+      ansible.builtin.command: cloud-init status --wait
+      changed_when: false
+
+    - name: Upgrade all packages
+      ansible.builtin.apt:
+        upgrade: dist
+        update_cache: true
+
+    - name: Install required packages
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - gnupg
+          - ufw
+          - fail2ban
+          - linux-headers-generic
+        state: present
+
+    - name: Install Nvidia open driver
+      ansible.builtin.apt:
+        name: "{{ nvidia_driver_package }}"
+        state: present
+      # Driver installation triggers a kernel module build — reboot required after this task
+      # if running for the first time. The play continues; reboot manually if nvidia-smi fails.
+
+    - name: Configure UFW — allow SSH from LAN
+      community.general.ufw:
+        rule: allow
+        port: "22"
+        proto: tcp
+        src: "192.168.1.0/24"
+
+    - name: Configure UFW — allow Ollama from LAN
+      community.general.ufw:
+        rule: allow
+        port: "11434"
+        proto: tcp
+        src: "192.168.1.0/24"
+
+    - name: Enable UFW
+      community.general.ufw:
+        state: enabled
+        policy: deny
+
+    - name: Enable fail2ban
+      ansible.builtin.service:
+        name: fail2ban
+        enabled: true
+        state: started

--- a/compute/ollama_vm/playbooks/create_vm.yml
+++ b/compute/ollama_vm/playbooks/create_vm.yml
@@ -1,0 +1,75 @@
+- name: Create VM from cloud-init template
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - ../group_vars/all/vars.yml
+    - ../group_vars/all/vault.yml
+  tasks:
+    # NOTE: GPU passthrough requires an Ubuntu 24.04 cloud-init template (vm_template_id: 9001).
+    # This is NOT template 9000 (Debian 12). Create the Ubuntu template first if it doesn't exist.
+    - name: Clone template
+      community.general.proxmox_kvm:
+        api_host:         "{{ proxmox_host }}"
+        api_user:         "{{ proxmox_api_user }}"
+        api_token_id:     "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+        node:    "{{ proxmox_node }}"
+        clone:   "{{ vm_template_id }}"
+        vmid:    "{{ vm_template_id }}"
+        name:    "{{ vm_name }}"
+        storage: "{{ vm_storage }}"
+        full:    true
+        state:   present
+
+    - name: Configure cloud-init and hardware (UEFI + q35 + GPU passthrough)
+      community.general.proxmox_kvm:
+        api_host:         "{{ proxmox_host }}"
+        api_user:         "{{ proxmox_api_user }}"
+        api_token_id:     "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+        node:    "{{ proxmox_node }}"
+        vmid:    "{{ vm_id }}"
+        cores:   "{{ vm_cores }}"
+        memory:  "{{ vm_memory_mb }}"
+        bios:    ovmf
+        machine: q35
+        hostpci:
+          hostpci0: "{{ vm_gpu_pcie }},pcie=1"
+        ipconfig:
+          ipconfig0: "ip={{ vm_ip }}/{{ vm_cidr }},gw={{ vm_gateway }}"
+        nameservers: ["{{ vm_nameserver }}"]
+        sshkeys: "{{ lookup('file', vm_ssh_key_path) }}"
+        cipassword: "{{ vault_vm_root_password }}"
+        update: true
+
+    - name: Resize disk
+      community.general.proxmox_disk:
+        api_host:         "{{ proxmox_host }}"
+        api_user:         "{{ proxmox_api_user }}"
+        api_token_id:     "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+        vmid:  "{{ vm_id }}"
+        disk:  scsi0
+        size:  "{{ vm_disk_size }}"
+        state: resized
+
+    - name: Wait for Proxmox lock to clear
+      ansible.builtin.pause:
+        seconds: 15
+
+    - name: Start VM
+      community.general.proxmox_kvm:
+        api_host:         "{{ proxmox_host }}"
+        api_user:         "{{ proxmox_api_user }}"
+        api_token_id:     "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+        node:  "{{ proxmox_node }}"
+        vmid:  "{{ vm_id }}"
+        state: started
+        timeout: 120
+
+    - name: Wait for SSH
+      ansible.builtin.wait_for:
+        host:    "{{ vm_ip }}"
+        port:    22
+        timeout: 120

--- a/compute/ollama_vm/playbooks/deploy_app.yml
+++ b/compute/ollama_vm/playbooks/deploy_app.yml
@@ -1,0 +1,105 @@
+- name: Deploy Ollama
+  hosts: ollama-gpu
+  gather_facts: false
+  vars_files:
+    - ../group_vars/all/vars.yml
+    - ../group_vars/all/vault.yml
+
+  tasks:
+    - name: Create ollama group
+      ansible.builtin.group:
+        name: ollama
+        system: true
+        state: present
+      become: true
+
+    - name: Create ollama user
+      ansible.builtin.user:
+        name: ollama
+        group: ollama
+        system: true
+        shell: /bin/false
+        home: /usr/share/ollama
+        create_home: true
+        state: present
+      become: true
+
+    - name: Check current Ollama version
+      ansible.builtin.command: /usr/local/bin/ollama --version
+      register: ollama_current_version
+      failed_when: false
+      changed_when: false
+
+    - name: Download Ollama binary
+      ansible.builtin.get_url:
+        url: "https://github.com/ollama/ollama/releases/download/v{{ ollama_version }}/ollama-linux-amd64"
+        dest: /usr/local/bin/ollama
+        mode: "0755"
+        owner: root
+        group: root
+      become: true
+      when: ollama_version not in (ollama_current_version.stdout | default(''))
+
+    - name: Install Ollama systemd service
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/ollama.service
+        content: |
+          [Unit]
+          Description=Ollama Service
+          After=network-online.target
+
+          [Service]
+          ExecStart=/usr/local/bin/ollama serve
+          User=ollama
+          Group=ollama
+          Restart=always
+          RestartSec=3
+          Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          Environment="OLLAMA_HOST={{ ollama_host }}"
+
+          [Install]
+          WantedBy=default.target
+        owner: root
+        group: root
+        mode: "0644"
+      become: true
+      notify: Restart Ollama
+
+    - name: Enable and start Ollama
+      ansible.builtin.systemd:
+        name: ollama
+        enabled: true
+        state: started
+        daemon_reload: true
+      become: true
+
+    - name: Wait for Ollama to be ready
+      ansible.builtin.uri:
+        url: "http://{{ vm_ip }}:11434"
+        method: GET
+        status_code: 200
+      register: ollama_status
+      until: ollama_status.status == 200
+      retries: 10
+      delay: 5
+      delegate_to: localhost
+
+    - name: Pull Ollama models
+      ansible.builtin.command:
+        cmd: "ollama pull {{ item }}"
+      loop: "{{ ollama_models }}"
+      become: true
+      become_user: ollama
+      environment:
+        OLLAMA_HOST: "http://{{ vm_ip }}:11434"
+      changed_when: true
+      delegate_to: localhost
+      # Note: large models (qwen3.5:9b = 6.6GB) can take several minutes each
+
+  handlers:
+    - name: Restart Ollama
+      ansible.builtin.systemd:
+        name: ollama
+        state: restarted
+        daemon_reload: true
+      become: true

--- a/compute/ollama_vm/playbooks/site.yml
+++ b/compute/ollama_vm/playbooks/site.yml
@@ -1,0 +1,3 @@
+- import_playbook: create_vm.yml
+- import_playbook: configure_vm.yml
+- import_playbook: deploy_app.yml

--- a/compute/ollama_vm/requirements.yml
+++ b/compute/ollama_vm/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - name: community.general    # proxmox_kvm, ufw
+  - name: ansible.posix        # sysctl


### PR DESCRIPTION
## Summary

- Reverse-engineered Ansible playbooks for the existing `ollama-gpu` VM (ID 101) by inspecting the live system
- Updated README with correct VM table (IP, GPU info)

## What's included

**`compute/ollama_vm/`** — full playbook structure mirroring the existing VM setup:
- `create_vm.yml` — clones from template 100 (Ubuntu 24.04 + Nvidia + Ollama golden image), configures UEFI/q35/PCIe GPU passthrough
- `configure_vm.yml` — apt upgrade, `nvidia-driver-590-open`, UFW (22 + 11434 from LAN), fail2ban
- `deploy_app.yml` — installs Ollama binary (v0.17.5), sets up systemd service with `OLLAMA_HOST=0.0.0.0:11434`, pulls all models
- `vars.yml` — pinned versions, model list, GPU PCI address

## Notes

- Template 100 is a golden image (pre-installed VM converted to template), not a clean cloud-init base
- Template was missing a cloud-init drive — fixed manually in Proxmox (drive added, ISO removed, ciuser set, boot order fixed)
- `make configure` and `make deploy` work against the existing VM; `make provision` requires template 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)