### PR TITLE
feat(network): add Loki for sentinel-trader log aggregation

### DIFF
--- a/network/Makefile
+++ b/network/Makefile
@@ -4,7 +4,7 @@
 .PHONY: help deploy update restart status logs stop start clean setup env rebuild-caddy
 
 # Service definitions
-SERVICES := pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared
+SERVICES := pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki
 OPERATIONS := deploy update restart status logs stop start push save
 BRANCH ?= main
 

--- a/network/caddy/Caddyfile
+++ b/network/caddy/Caddyfile
@@ -184,6 +184,26 @@
         }
     }
 
+    @loki host loki.mati-lab.online
+    handle @loki {
+        @loki_health path /ready
+        handle @loki_health {
+            reverse_proxy http://loki:3100
+        }
+
+        handle {
+            forward_auth http://authelia:9091 {
+                uri /api/authz/forward-auth
+                copy_headers Remote-User Remote-Groups Remote-Name Remote-Email
+            }
+            reverse_proxy http://loki:3100 {
+                header_up Host {host}
+                header_up X-Forwarded-Proto https
+                header_up X-Forwarded-Ssl on
+            }
+        }
+    }
+
     handle {
         respond "unknown host" 404
     }

--- a/network/grafana/provisioning/datasources/loki.yml
+++ b/network/grafana/provisioning/datasources/loki.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: loki-sentinel
+    type: loki
+    url: http://loki:3100
+    access: proxy
+    editable: true

--- a/network/loki/docker-compose.yml
+++ b/network/loki/docker-compose.yml
@@ -1,0 +1,21 @@
+networks:
+  pihole-net:
+    external: true
+
+volumes:
+  loki-data: {}
+
+services:
+  loki:
+    image: grafana/loki:3.5.0
+    container_name: loki
+    restart: always
+    command: -config.file=/etc/loki/loki-config.yml
+    volumes:
+      - ./loki-config.yml:/etc/loki/loki-config.yml
+      - loki-data:/loki
+    networks:
+      - pihole-net
+    labels:
+      - "com.docker.compose.project=loki"
+      - "com.docker.compose.service=loki"

--- a/network/loki/loki-config.yml
+++ b/network/loki/loki-config.yml
@@ -1,0 +1,38 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+  # Retain logs for 30 days
+  retention_period: 720h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  retention_delete_delay: 2h
+  delete_request_store: filesystem

--- a/network/prometheus/prometheus.yml
+++ b/network/prometheus/prometheus.yml
@@ -22,3 +22,8 @@ scrape_configs:
   - job_name: caddy
     static_configs:
       - targets: [ 'caddy:2019' ]
+
+  - job_name: sentinel-trader
+    scrape_interval: 30s
+    static_configs:
+      - targets: [ 'sentinel-trader:9090' ]

--- a/network/scripts/manage-all.sh
+++ b/network/scripts/manage-all.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Available services
-SERVICES=(pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared)
+SERVICES=(pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki)
 
 log_success(){ printf "\033[0;32m[SUCCESS]\033[0m %s\n" "$*"; }
 log_warning(){ printf "\033[1;33m[WARNING]\033[0m %s\n" "$*"; }

--- a/network/scripts/manage-loki.sh
+++ b/network/scripts/manage-loki.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SERVICE_NAME="loki"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+save() { push; }
+
+# Handle command line arguments
+case "${1:-help}" in
+  deploy|update|restart|start|stop|status|logs|push|save) "$1" ;;
+  *) echo "usage: $0 {deploy|update|restart|start|stop|status|logs|push|save}"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- **Loki 3.5.0** deployed on `pihole-net` with persistent volume, 30-day retention, TSDB schema v13
- **Grafana datasource** auto-provisioned (`loki-sentinel`) — visible immediately after `docker compose restart grafana`
- **Prometheus** scrape job added for `sentinel-trader:9090` (30s interval)

## Deploy order
1. `cd network/loki && docker compose up -d`
2. `cd network/grafana && docker compose restart`
3. `cd network/prometheus && docker compose restart`

## Test plan
- [ ] Loki healthy: `curl http://loki:3100/ready` → `ready`
- [ ] Datasource visible in Grafana → Connections → Data sources
- [ ] After sentinel-trader PR #16 deployed, logs appear in Grafana Explore

🤖 Generated with [Claude Code](https://claude.com/claude-code)