### PR TITLE
security: hardening round 2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.1
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e  # v8.30.1
     hooks:
       - id: gitleaks
 
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.5.0
+    rev: 01886c8a910c64595c47f186ca1ffc0b77fa5458  # v1.5.0
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']

--- a/network/authelia/docker-compose.yml
+++ b/network/authelia/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ./redis-data:/data
     restart: unless-stopped
+    security_opt: [no-new-privileges:true]
     networks:
       - pihole-net
     labels:
@@ -27,6 +28,7 @@ services:
     ports:
       - 9091:9091
     restart: unless-stopped
+    security_opt: [no-new-privileges:true]
     depends_on:
       - redis
     networks:

--- a/network/caddy/docker-compose.yml
+++ b/network/caddy/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       dockerfile: Dockerfile
     container_name: caddy
     restart: unless-stopped
+    security_opt: [no-new-privileges:true]
     dns:
       - 1.1.1.1
       - 1.0.0.1

--- a/network/cloudflared/docker-compose.yml
+++ b/network/cloudflared/docker-compose.yml
@@ -4,5 +4,6 @@ services:
     container_name: cloudflared
     command: tunnel --no-autoupdate run
     restart: unless-stopped
+    security_opt: [no-new-privileges:true]
     environment:
       - TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN}

--- a/network/diun/docker-compose.yml
+++ b/network/diun/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - "DIUN_NOTIF_NTFY_PRIORITY=3"
       - "DIUN_NOTIF_NTFY_TAGS=package"
     restart: unless-stopped
+    security_opt: [no-new-privileges:true]
 
     networks:
       - pihole-net

--- a/network/grafana/docker-compose.yml
+++ b/network/grafana/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     image: grafana/grafana:12.3.0-17718666199
     container_name: grafana
     restart: always
+    security_opt: [no-new-privileges:true]
     env_file:
       - .env
     volumes:

--- a/network/homarr/docker-compose.yml
+++ b/network/homarr/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     container_name: homarr
     image: ghcr.io/homarr-labs/homarr:v1.53.0
     restart: unless-stopped
+    security_opt: [no-new-privileges:true]
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./appdata:/appdata

--- a/network/loki/docker-compose.yml
+++ b/network/loki/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     image: grafana/loki:3.5.0
     container_name: loki
     restart: always
+    security_opt: [no-new-privileges:true]
     command: -config.file=/etc/loki/loki-config.yml
     ports:
       - "192.168.1.252:3100:3100"   # LAN push endpoint for Promtail on remote VMs

--- a/network/network-pi-metrics/docker-compose.yml
+++ b/network/network-pi-metrics/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     image: prom/node-exporter:v1.10.2
     container_name: node-exporter
     restart: always
+    security_opt: [no-new-privileges:true]
     networks: [monitoring]
     pid: host
     command:
@@ -26,6 +27,7 @@ services:
     image: gcr.io/cadvisor/cadvisor:v0.56.2
     container_name: cadvisor
     restart: always
+    security_opt: [no-new-privileges:true]
     networks: [monitoring]
     privileged: true
     command:

--- a/network/ntfy/docker-compose.yml
+++ b/network/ntfy/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       retries: 3
       start_period: 40s
     restart: unless-stopped
+    security_opt: [no-new-privileges:true]
     init: true
 
     networks:

--- a/network/pihole/docker-compose.yml
+++ b/network/pihole/docker-compose.yml
@@ -26,11 +26,10 @@ services:
       - VIRTUAL_HOST=pihole.mati-lab.online
       - PROXY_LOCATION=/
       - PROXY_SUBDIR=/
-    cap_add:
-      - SYS_NICE
-      - NET_ADMIN
-      - NET_BROADCAST
+    cap_add: [NET_ADMIN, NET_RAW]
+    cap_drop: [ALL]
     restart: always
+    security_opt: [no-new-privileges:true]
     labels:
       - "com.docker.compose.project=pihole"
       - "com.docker.compose.service=pihole"

--- a/network/prometheus/docker-compose.yml
+++ b/network/prometheus/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: prom/prometheus:v3.5.0
     container_name: prometheus
     restart: always
+    security_opt: [no-new-privileges:true]
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus

--- a/network/uptime-kuma/docker-compose.yml
+++ b/network/uptime-kuma/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: louislam/uptime-kuma:2.1.0
     container_name: uptime-kuma
     restart: unless-stopped
+    security_opt: [no-new-privileges:true]
     environment:
       - UPTIME_KUMA_DISABLE_FRAME_SAMEORIGIN=true
     volumes:


### PR DESCRIPTION
## Summary
- Docker runtime hardening: `security_opt: [no-new-privileges:true]` on all services across all docker-compose files
- Pin pre-commit hooks to commit SHAs instead of mutable tags
- Pihole: replaced broad `cap_add` (SYS_NICE, NET_ADMIN, NET_BROADCAST) with minimal `cap_add: [NET_ADMIN, NET_RAW]` + `cap_drop: [ALL]`

## Risk
Low — `no-new-privileges` prevents privilege escalation inside containers. If any service fails to start, the flag can be removed for that specific service.