### PR TITLE
feat: fix network-pi-metrics + add Docker registry mirror

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,11 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "docker"
+    directory: "/network/registry-mirror"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint & validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install tools
+        run: |
+          pip install --quiet yamllint
+          sudo apt-get install -y -qq shellcheck > /dev/null
+
+      - name: YAML lint
+        run: yamllint -d '{extends: relaxed, rules: {line-length: disable, truthy: disable}}' network/*/docker-compose.yml compute/*/playbooks/*.yml
+
+      - name: Shell lint
+        run: shellcheck network/scripts/*.sh
+
+      - name: Docker Compose validate
+        run: |
+          failed=0
+          for f in network/*/docker-compose.yml; do
+            dir=$(dirname "$f")
+            if ! docker compose -f "$f" config --quiet 2>/dev/null; then
+              echo "::error file=$f::Invalid compose file"
+              failed=1
+            fi
+          done
+          exit $failed

--- a/network/Makefile
+++ b/network/Makefile
@@ -4,7 +4,7 @@
 .PHONY: help deploy update restart status logs stop start clean setup env rebuild-caddy
 
 # Service definitions
-SERVICES := pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki
+SERVICES := pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki network-pi-metrics registry-mirror
 OPERATIONS := deploy update restart status logs stop start push save
 BRANCH ?= main
 

--- a/network/network-pi-metrics/docker-compose.yml
+++ b/network/network-pi-metrics/docker-compose.yml
@@ -1,7 +1,6 @@
 networks:
   pihole-net:
-    name: pihole-net
-    driver: bridge
+    external: true
 
 services:
   node-exporter:
@@ -9,7 +8,7 @@ services:
     container_name: node-exporter
     restart: always
     security_opt: [no-new-privileges:true]
-    networks: [monitoring]
+    networks: [pihole-net]
     pid: host
     command:
       - '--path.rootfs=/rootfs'
@@ -24,11 +23,11 @@ services:
       - node_textfile:/var/lib/node_exporter/textfile_collector:rw
 
   cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.56.2
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
     container_name: cadvisor
     restart: always
     security_opt: [no-new-privileges:true]
-    networks: [monitoring]
+    networks: [pihole-net]
     privileged: true
     command:
       - '-port=9092'
@@ -39,3 +38,5 @@ services:
       - /var/lib/docker/:/var/lib/docker:ro
       - /dev/disk/:/dev/disk:ro
 
+volumes:
+  node_textfile: {}

--- a/network/registry-mirror/docker-compose.yml
+++ b/network/registry-mirror/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     security_opt: [no-new-privileges:true]
     networks: [pihole-net]
     ports:
-      - "127.0.0.1:5000:5000"
+      - "5000:5000"
     environment:
       REGISTRY_PROXY_REMOTEURL: https://registry-1.docker.io
       REGISTRY_STORAGE_DELETE_ENABLED: "true"

--- a/network/registry-mirror/docker-compose.yml
+++ b/network/registry-mirror/docker-compose.yml
@@ -1,0 +1,22 @@
+networks:
+  pihole-net:
+    external: true
+
+services:
+  registry-mirror:
+    image: registry:2
+    container_name: registry-mirror
+    restart: always
+    security_opt: [no-new-privileges:true]
+    networks: [pihole-net]
+    ports:
+      - "127.0.0.1:5000:5000"
+    environment:
+      REGISTRY_PROXY_REMOTEURL: https://registry-1.docker.io
+      REGISTRY_STORAGE_DELETE_ENABLED: "true"
+      REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR: inmemory
+    volumes:
+      - registry-data:/var/lib/registry
+
+volumes:
+  registry-data: {}

--- a/network/scripts/manage-all.sh
+++ b/network/scripts/manage-all.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Available services
-SERVICES=(pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki)
+SERVICES=(pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki network-pi-metrics registry-mirror)
 
 log_success(){ printf "\033[0;32m[SUCCESS]\033[0m %s\n" "$*"; }
 log_warning(){ printf "\033[1;33m[WARNING]\033[0m %s\n" "$*"; }

--- a/network/scripts/manage-network-pi-metrics.sh
+++ b/network/scripts/manage-network-pi-metrics.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SERVICE_NAME="network-pi-metrics"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+save() { push; }
+
+# Handle command line arguments
+case "${1:-help}" in
+  deploy|update|restart|start|stop|status|logs|push|save) "$1" ;;
+  *) echo "usage: $0 {deploy|update|restart|start|stop|status|logs|push|save}"; exit 1 ;;
+esac

--- a/network/scripts/manage-registry-mirror.sh
+++ b/network/scripts/manage-registry-mirror.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SERVICE_NAME="registry-mirror"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+save() { push; }
+
+# Handle command line arguments
+case "${1:-help}" in
+  deploy|update|restart|start|stop|status|logs|push|save) "$1" ;;
+  *) echo "usage: $0 {deploy|update|restart|start|stop|status|logs|push|save}"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- **network-pi-metrics**: Fix broken compose (wrong network name, cadvisor version without arm64 support). Add management script and register in SERVICES list so it actually gets deployed.
- **registry-mirror**: Docker Hub pull-through cache to eliminate rate limits across all LAN machines (~50MB RAM).

## What was broken
node-exporter and cadvisor were never running because:
1. The service wasn't in the SERVICES list in `manage-all.sh` / `Makefile`
2. The compose referenced a `monitoring` network that doesn't exist (should be `pihole-net`)
3. `cadvisor:v0.56.2` doesn't have arm64 images — switched to `v0.52.1`

## After merging
1. Deploy network-pi-metrics: `cd network && make deploy-network-pi-metrics`
2. Deploy registry-mirror: `cd network && make deploy-registry-mirror`
3. Configure Docker daemon on Pi + VMs to use the mirror (add to `/etc/docker/daemon.json`):
   ```json
   { "registry-mirrors": ["http://192.168.1.252:5000"] }
   ```
4. Import a Grafana dashboard for Node Exporter + cAdvisor (e.g., dashboard ID 1860 or 11074)