### PR TITLE
fix: PVE exporter — use .env instead of config file placeholder

### DIFF
--- a/network/pve-exporter/.env.example
+++ b/network/pve-exporter/.env.example
@@ -1,5 +1,7 @@
 # Proxmox API token — create in Proxmox UI:
-# Datacenter → Permissions → API Tokens → Add
-# User: prometheus@pve, Token ID: prometheus, Privilege Separation: unchecked
-# Then copy the token value (shown only once)
-PVE_HOST=192.168.1.184
+# 1. Datacenter → Permissions → Users → Add (prometheus@pve, realm: pve)
+# 2. Datacenter → Permissions → API Tokens → Add (user: prometheus@pve, token ID: prometheus, uncheck privilege separation)
+# 3. Datacenter → Permissions → Add → API Token Permission (path: /, token: prometheus@pve!prometheus, role: PVEAuditor)
+PVE_USER=prometheus@pve
+PVE_TOKEN_NAME=prometheus
+PVE_TOKEN_VALUE=your-token-value-here

--- a/network/pve-exporter/docker-compose.yml
+++ b/network/pve-exporter/docker-compose.yml
@@ -9,11 +9,13 @@ services:
     restart: always
     security_opt: [no-new-privileges:true]
     networks: [pihole-net]
+    environment:
+      PVE_USER: ${PVE_USER}
+      PVE_TOKEN_NAME: ${PVE_TOKEN_NAME}
+      PVE_TOKEN_VALUE: ${PVE_TOKEN_VALUE}
+      PVE_VERIFY_SSL: "false"
     env_file:
       - .env
-    volumes:
-      - ./pve.yml:/etc/pve.yml:ro
-    command: ["--config.file", "/etc/pve.yml"]
     labels:
       - "com.docker.compose.project=pve-exporter"
       - "com.docker.compose.service=pve-exporter"

--- a/network/pve-exporter/pve.yml
+++ b/network/pve-exporter/pve.yml
@@ -1,5 +1,0 @@
-default:
-  user: prometheus@pve
-  token_name: prometheus
-  token_value: __PVE_API_TOKEN__
-  verify_ssl: false


### PR DESCRIPTION
## Summary
Replace the `pve.yml` config file (had a `__PVE_API_TOKEN__` placeholder) with environment variables loaded from `.env` (gitignored). The deploy script's `copy_env_file` syncs the `.env` to the Pi automatically.

## Setup
1. Copy `.env.example` to `.env` in `network/pve-exporter/`
2. Fill in the token value
3. Deploy: `./manage-pve-exporter.sh deploy`