### PR TITLE
feat: container log shipping to Loki + Grafana logs dashboard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -70,6 +70,11 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "docker"
+    directory: "/network/promtail"
+    schedule:
+      interval: "weekly"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/network/Makefile
+++ b/network/Makefile
@@ -4,7 +4,7 @@
 .PHONY: help deploy update restart status logs stop start clean setup env rebuild-caddy
 
 # Service definitions
-SERVICES := pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki network-pi-metrics registry-mirror pve-exporter
+SERVICES := pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki network-pi-metrics registry-mirror pve-exporter promtail
 OPERATIONS := deploy update restart status logs stop start push save
 BRANCH ?= main
 

--- a/network/grafana/provisioning/dashboards/container-logs.json
+++ b/network/grafana/provisioning/dashboards/container-logs.json
@@ -37,6 +37,7 @@
         "query": "info,warn,error,fatal,debug",
         "includeAll": true,
         "multi": true,
+        "allValue": ".*",
         "current": {
           "selected": true,
           "text": "All",
@@ -78,7 +79,7 @@
       "datasource": "loki-sentinel",
       "targets": [
         {
-          "expr": "sum by (container) (count_over_time({container=~\"$container\"} |~ \"(?i)error|fatal|panic\" [$__interval]))",
+          "expr": "sum by (container) (count_over_time({container=~\"$container\"} |~ \"(?i)(error|fatal|panic|warn|warning)\" [$__interval]))",
           "legendFormat": "{{container}}"
         }
       ],
@@ -100,7 +101,7 @@
       "datasource": "loki-sentinel",
       "targets": [
         {
-          "expr": "{container=~\"$container\"} |~ \"(?i)$search\" |~ \"(?i)$level\"",
+          "expr": "{container=~\"$container\"} |~ \"(?i)$search\" |~ \"(?i)${level:regex}\"",
           "refId": "A"
         }
       ],

--- a/network/grafana/provisioning/dashboards/container-logs.json
+++ b/network/grafana/provisioning/dashboards/container-logs.json
@@ -1,0 +1,122 @@
+{
+  "id": null,
+  "title": "Container Logs",
+  "tags": ["logs", "docker", "loki"],
+  "timezone": "browser",
+  "refresh": "10s",
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "name": "container",
+        "type": "query",
+        "datasource": "loki-sentinel",
+        "query": "label_values(container)",
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "sort": 1
+      },
+      {
+        "name": "search",
+        "type": "textbox",
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "label": "Search"
+      },
+      {
+        "name": "level",
+        "type": "custom",
+        "query": "info,warn,error,fatal,debug",
+        "includeAll": true,
+        "multi": true,
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "label": "Level"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "title": "Log Volume",
+      "type": "timeseries",
+      "gridPos": { "h": 5, "w": 24, "x": 0, "y": 0 },
+      "datasource": "loki-sentinel",
+      "targets": [
+        {
+          "expr": "sum by (container) (count_over_time({container=~\"$container\"} [$__interval]))",
+          "legendFormat": "{{container}}"
+        }
+      ],
+      "options": {
+        "tooltip": { "mode": "multi" }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 50,
+            "stacking": { "mode": "normal" }
+          }
+        }
+      }
+    },
+    {
+      "title": "Errors & Warnings",
+      "type": "timeseries",
+      "gridPos": { "h": 4, "w": 24, "x": 0, "y": 5 },
+      "datasource": "loki-sentinel",
+      "targets": [
+        {
+          "expr": "sum by (container) (count_over_time({container=~\"$container\"} |~ \"(?i)error|fatal|panic\" [$__interval]))",
+          "legendFormat": "{{container}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 70,
+            "stacking": { "mode": "normal" }
+          },
+          "color": { "mode": "fixed", "fixedColor": "red" }
+        }
+      }
+    },
+    {
+      "title": "Logs",
+      "type": "logs",
+      "gridPos": { "h": 18, "w": 24, "x": 0, "y": 9 },
+      "datasource": "loki-sentinel",
+      "targets": [
+        {
+          "expr": "{container=~\"$container\"} |~ \"(?i)$search\" |~ \"(?i)$level\"",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showTime": true,
+        "showLabels": true,
+        "showCommonLabels": false,
+        "wrapLogMessage": true,
+        "sortOrder": "Descending",
+        "dedupStrategy": "none",
+        "enableLogDetails": true
+      }
+    }
+  ],
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  }
+}

--- a/network/promtail/docker-compose.yml
+++ b/network/promtail/docker-compose.yml
@@ -1,0 +1,19 @@
+networks:
+  pihole-net:
+    external: true
+
+services:
+  promtail:
+    image: grafana/promtail:3.5.0
+    container_name: promtail
+    restart: always
+    security_opt: [no-new-privileges:true]
+    networks: [pihole-net]
+    command: -config.file=/etc/promtail/promtail-config.yml
+    volumes:
+      - ./promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    labels:
+      - "com.docker.compose.project=promtail"
+      - "com.docker.compose.service=promtail"

--- a/network/promtail/docker-compose.yml
+++ b/network/promtail/docker-compose.yml
@@ -2,18 +2,41 @@ networks:
   pihole-net:
     external: true
 
+volumes:
+  promtail-positions: {}
+
 services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:edge
+    container_name: docker-socket-proxy
+    restart: always
+    security_opt: [no-new-privileges:true]
+    networks: [pihole-net]
+    environment:
+      CONTAINERS: 1
+      IMAGES: 0
+      NETWORKS: 0
+      VOLUMES: 0
+      INFO: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    labels:
+      - "com.docker.compose.project=promtail"
+      - "com.docker.compose.service=docker-socket-proxy"
+
   promtail:
     image: grafana/promtail:3.5.0
     container_name: promtail
     restart: always
     security_opt: [no-new-privileges:true]
     networks: [pihole-net]
+    depends_on:
+      - docker-socket-proxy
     command: -config.file=/etc/promtail/promtail-config.yml
     volumes:
       - ./promtail-config.yml:/etc/promtail/promtail-config.yml:ro
-      - /var/run/docker.sock:/var/run/docker.sock:ro
       - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - promtail-positions:/var/lib/promtail
     labels:
       - "com.docker.compose.project=promtail"
       - "com.docker.compose.service=promtail"

--- a/network/promtail/promtail-config.yml
+++ b/network/promtail/promtail-config.yml
@@ -1,0 +1,33 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 10s
+    relabel_configs:
+      # Use container name as the primary label
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'container'
+      # Add compose project label
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: 'compose_project'
+      # Add compose service label
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: 'compose_service'
+      # Add host label
+      - target_label: 'host'
+        replacement: 'network-pi'
+      # Drop promtail's own logs to avoid recursion
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/promtail'
+        action: drop

--- a/network/promtail/promtail-config.yml
+++ b/network/promtail/promtail-config.yml
@@ -3,7 +3,7 @@ server:
   grpc_listen_port: 0
 
 positions:
-  filename: /tmp/positions.yaml
+  filename: /var/lib/promtail/positions.yaml
 
 clients:
   - url: http://loki:3100/loki/api/v1/push
@@ -11,7 +11,7 @@ clients:
 scrape_configs:
   - job_name: docker
     docker_sd_configs:
-      - host: unix:///var/run/docker.sock
+      - host: tcp://docker-socket-proxy:2375
         refresh_interval: 10s
     relabel_configs:
       # Use container name as the primary label
@@ -27,7 +27,7 @@ scrape_configs:
       # Add host label
       - target_label: 'host'
         replacement: 'network-pi'
-      # Drop promtail's own logs to avoid recursion
+      # Drop promtail and socket proxy logs to avoid recursion
       - source_labels: ['__meta_docker_container_name']
-        regex: '/promtail'
+        regex: '/(promtail|docker-socket-proxy)'
         action: drop

--- a/network/scripts/manage-all.sh
+++ b/network/scripts/manage-all.sh
@@ -7,7 +7,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Available services
-SERVICES=(pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki network-pi-metrics registry-mirror pve-exporter)
+SERVICES=(pihole authelia caddy uptime-kuma homarr prometheus grafana ntfy diun cloudflared loki network-pi-metrics registry-mirror pve-exporter promtail)
 
 log_success(){ printf "\033[0;32m[SUCCESS]\033[0m %s\n" "$*"; }
 log_warning(){ printf "\033[1;33m[WARNING]\033[0m %s\n" "$*"; }

--- a/network/scripts/manage-promtail.sh
+++ b/network/scripts/manage-promtail.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# shellcheck disable=SC2034 # used by common.sh after source
+SERVICE_NAME="promtail"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=network/scripts/common.sh
+source "$SCRIPT_DIR/common.sh"
+
+save() { push; }
+
+# Handle command line arguments
+case "${1:-help}" in
+  deploy|update|restart|start|stop|status|logs|push|save) "$1" ;;
+  *) echo "usage: $0 {deploy|update|restart|start|stop|status|logs|push|save}"; exit 1 ;;
+esac


### PR DESCRIPTION
## Summary
- Add Promtail service that auto-discovers all Docker containers and ships logs to Loki
- Add Grafana "Container Logs" dashboard with container dropdown, text search, and level filter

## Dashboard features
- **Container filter**: multi-select dropdown, auto-populated from Loki labels
- **Search**: free-text filter across all log lines
- **Level filter**: info/warn/error/fatal/debug
- **Log volume**: stacked bar chart per container
- **Error chart**: highlights errors/fatals
- **Live logs**: streaming log panel with full details

## After merge
```bash
cd network/scripts
./manage-promtail.sh deploy
./manage-grafana.sh deploy
```