### PR TITLE
fix: enable NETWORKS in docker-socket-proxy for promtail

### DIFF
--- a/network/promtail/docker-compose.yml
+++ b/network/promtail/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     environment:
       CONTAINERS: 1
       IMAGES: 0
-      NETWORKS: 0
+      NETWORKS: 1
       VOLUMES: 0
       INFO: 0
     volumes:


### PR DESCRIPTION
Promtail needs Networks API access to discover containers. Already applied live on Pi — this codifies the fix.