### PR TITLE
feat: private registry on :5001 + Docker daemon config on compute VMs

### DIFF
--- a/compute/sentinel_trader_vm/group_vars/all/vars.yml
+++ b/compute/sentinel_trader_vm/group_vars/all/vars.yml
@@ -28,6 +28,11 @@ vm_ssh_key_path: "~/.ssh/id_ed25519.pub"
 app_repo_path: "/home/gooral/Projects/sentinel-trader"
 app_remote_path: "/opt/sentinel-trader"
 
+# Docker
+docker_registry_mirror: "http://192.168.1.252:5000"
+docker_log_max_size: "10m"
+docker_log_max_file: "3"
+
 # Monitoring host (192.168.1.252 — runs Prometheus + Loki on pihole-net)
 monitoring_host_ip: "192.168.1.252"
 loki_url: "http://192.168.1.252:3100"

--- a/compute/sentinel_trader_vm/playbooks/configure_vm.yml
+++ b/compute/sentinel_trader_vm/playbooks/configure_vm.yml
@@ -56,6 +56,25 @@
     - name: Reset SSH connection to pick up new group membership
       ansible.builtin.meta: reset_connection
 
+    - name: Configure Docker daemon
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        mode: "0644"
+        content: |
+          {
+            "registry-mirrors": ["{{ docker_registry_mirror }}"],
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "{{ docker_log_max_size }}",
+              "max-file": "{{ docker_log_max_file }}"
+            },
+            "default-address-pools": [
+              { "base": "172.17.0.0/16", "size": 24 },
+              { "base": "172.18.0.0/16", "size": 24 }
+            ]
+          }
+      notify: Restart Docker
+
     - name: Configure UFW — allow SSH
       community.general.ufw:
         rule: allow
@@ -79,3 +98,9 @@
         name: fail2ban
         enabled: true
         state: started
+
+  handlers:
+    - name: Restart Docker
+      ansible.builtin.systemd:
+        name: docker
+        state: restarted

--- a/compute/sentinel_trader_vm/playbooks/configure_vm.yml
+++ b/compute/sentinel_trader_vm/playbooks/configure_vm.yml
@@ -57,22 +57,10 @@
       ansible.builtin.meta: reset_connection
 
     - name: Configure Docker daemon
-      ansible.builtin.copy:
+      ansible.builtin.template:
+        src: ../../../network/ansible/templates/daemon.json.j2
         dest: /etc/docker/daemon.json
         mode: "0644"
-        content: |
-          {
-            "registry-mirrors": ["{{ docker_registry_mirror }}"],
-            "log-driver": "json-file",
-            "log-opts": {
-              "max-size": "{{ docker_log_max_size }}",
-              "max-file": "{{ docker_log_max_file }}"
-            },
-            "default-address-pools": [
-              { "base": "172.17.0.0/16", "size": 24 },
-              { "base": "172.18.0.0/16", "size": 24 }
-            ]
-          }
       notify: Restart Docker
 
     - name: Configure UFW — allow SSH

--- a/compute/smart_resume_vm/group_vars/all/vars.yml
+++ b/compute/smart_resume_vm/group_vars/all/vars.yml
@@ -24,6 +24,11 @@ vm_cidr: 24
 vm_ssh_user: "debian"
 vm_ssh_key_path: "~/.ssh/id_ed25519.pub"
 
+# Docker
+docker_registry_mirror: "http://192.168.1.252:5000"
+docker_log_max_size: "10m"
+docker_log_max_file: "3"
+
 # App
 app_repo_path: "/home/gooral/Projects/smart-resume"
 app_remote_path: "/opt/smart-resume"

--- a/compute/smart_resume_vm/playbooks/configure_vm.yml
+++ b/compute/smart_resume_vm/playbooks/configure_vm.yml
@@ -52,22 +52,10 @@
       ansible.builtin.meta: reset_connection
 
     - name: Configure Docker daemon
-      ansible.builtin.copy:
+      ansible.builtin.template:
+        src: ../../../network/ansible/templates/daemon.json.j2
         dest: /etc/docker/daemon.json
         mode: "0644"
-        content: |
-          {
-            "registry-mirrors": ["{{ docker_registry_mirror }}"],
-            "log-driver": "json-file",
-            "log-opts": {
-              "max-size": "{{ docker_log_max_size }}",
-              "max-file": "{{ docker_log_max_file }}"
-            },
-            "default-address-pools": [
-              { "base": "172.17.0.0/16", "size": 24 },
-              { "base": "172.18.0.0/16", "size": 24 }
-            ]
-          }
       notify: Restart Docker
 
     - name: Configure UFW — allow SSH

--- a/compute/smart_resume_vm/playbooks/configure_vm.yml
+++ b/compute/smart_resume_vm/playbooks/configure_vm.yml
@@ -51,6 +51,25 @@
     - name: Reset SSH connection to pick up new group membership
       ansible.builtin.meta: reset_connection
 
+    - name: Configure Docker daemon
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        mode: "0644"
+        content: |
+          {
+            "registry-mirrors": ["{{ docker_registry_mirror }}"],
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "{{ docker_log_max_size }}",
+              "max-file": "{{ docker_log_max_file }}"
+            },
+            "default-address-pools": [
+              { "base": "172.17.0.0/16", "size": 24 },
+              { "base": "172.18.0.0/16", "size": 24 }
+            ]
+          }
+      notify: Restart Docker
+
     - name: Configure UFW — allow SSH
       community.general.ufw:
         rule: allow
@@ -73,3 +92,9 @@
         name: fail2ban
         enabled: true
         state: started
+
+  handlers:
+    - name: Restart Docker
+      ansible.builtin.systemd:
+        name: docker
+        state: restarted

--- a/compute/sonarqube_vm/group_vars/all/vars.yml
+++ b/compute/sonarqube_vm/group_vars/all/vars.yml
@@ -24,6 +24,11 @@ vm_cidr: 24
 vm_ssh_user: "debian"
 vm_ssh_key_path: "~/.ssh/id_ed25519.pub"
 
+# Docker
+docker_registry_mirror: "http://192.168.1.252:5000"
+docker_log_max_size: "10m"
+docker_log_max_file: "3"
+
 # App paths
 app_remote_path: "/opt/sonarqube"
 

--- a/compute/sonarqube_vm/playbooks/configure_vm.yml
+++ b/compute/sonarqube_vm/playbooks/configure_vm.yml
@@ -56,22 +56,10 @@
       ansible.builtin.meta: reset_connection
 
     - name: Configure Docker daemon
-      ansible.builtin.copy:
+      ansible.builtin.template:
+        src: ../../../network/ansible/templates/daemon.json.j2
         dest: /etc/docker/daemon.json
         mode: "0644"
-        content: |
-          {
-            "registry-mirrors": ["{{ docker_registry_mirror }}"],
-            "log-driver": "json-file",
-            "log-opts": {
-              "max-size": "{{ docker_log_max_size }}",
-              "max-file": "{{ docker_log_max_file }}"
-            },
-            "default-address-pools": [
-              { "base": "172.17.0.0/16", "size": 24 },
-              { "base": "172.18.0.0/16", "size": 24 }
-            ]
-          }
       notify: Restart Docker
 
     - name: Configure UFW — allow SSH

--- a/compute/sonarqube_vm/playbooks/configure_vm.yml
+++ b/compute/sonarqube_vm/playbooks/configure_vm.yml
@@ -55,6 +55,25 @@
     - name: Reset SSH connection to pick up new group membership
       ansible.builtin.meta: reset_connection
 
+    - name: Configure Docker daemon
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        mode: "0644"
+        content: |
+          {
+            "registry-mirrors": ["{{ docker_registry_mirror }}"],
+            "log-driver": "json-file",
+            "log-opts": {
+              "max-size": "{{ docker_log_max_size }}",
+              "max-file": "{{ docker_log_max_file }}"
+            },
+            "default-address-pools": [
+              { "base": "172.17.0.0/16", "size": 24 },
+              { "base": "172.18.0.0/16", "size": 24 }
+            ]
+          }
+      notify: Restart Docker
+
     - name: Configure UFW — allow SSH
       community.general.ufw:
         rule: allow
@@ -92,3 +111,9 @@
         value: "131072"
         state: present
         reload: true
+
+  handlers:
+    - name: Restart Docker
+      ansible.builtin.systemd:
+        name: docker
+        state: restarted

--- a/network/ansible/group_vars/all/vars.yml
+++ b/network/ansible/group_vars/all/vars.yml
@@ -22,6 +22,7 @@ ufw_rules:
   - { rule: allow, port: "53", proto: tcp, from: "172.18.0.0/16", comment: "DNS TCP Docker" }
   - { rule: allow, port: "53", proto: udp, from: "172.18.0.0/16", comment: "DNS UDP Docker" }
   - { rule: allow, port: "5000", proto: tcp, from: "192.168.1.0/24", comment: "Docker registry mirror LAN" }
+  - { rule: allow, port: "5001", proto: tcp, from: "192.168.1.0/24", comment: "Docker private registry LAN" }
 
 # fail2ban
 fail2ban_maxretry: 5

--- a/network/caddy/docker-compose.yml
+++ b/network/caddy/docker-compose.yml
@@ -4,7 +4,7 @@ networks:
 
 services:
   caddy:
-    image: 192.168.1.252:5000/caddy-cloudflare:latest
+    image: 192.168.1.252:5001/caddy-cloudflare:latest
     container_name: caddy
     restart: unless-stopped
     security_opt: [no-new-privileges:true]

--- a/network/registry-mirror/docker-compose.yml
+++ b/network/registry-mirror/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       REGISTRY_STORAGE_DELETE_ENABLED: "true"
       REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR: inmemory
     volumes:
-      - registry-mirror-data:/var/lib/registry
+      - registry-data:/var/lib/registry
 
   registry-private:
     image: registry:2
@@ -32,5 +32,5 @@ services:
       - registry-private-data:/var/lib/registry
 
 volumes:
-  registry-mirror-data: {}
+  registry-data: {}
   registry-private-data: {}

--- a/network/registry-mirror/docker-compose.yml
+++ b/network/registry-mirror/docker-compose.yml
@@ -16,7 +16,21 @@ services:
       REGISTRY_STORAGE_DELETE_ENABLED: "true"
       REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR: inmemory
     volumes:
-      - registry-data:/var/lib/registry
+      - registry-mirror-data:/var/lib/registry
+
+  registry-private:
+    image: registry:2
+    container_name: registry-private
+    restart: always
+    security_opt: [no-new-privileges:true]
+    networks: [pihole-net]
+    ports:
+      - "5001:5000"
+    environment:
+      REGISTRY_STORAGE_DELETE_ENABLED: "true"
+    volumes:
+      - registry-private-data:/var/lib/registry
 
 volumes:
-  registry-data: {}
+  registry-mirror-data: {}
+  registry-private-data: {}

--- a/network/registry-mirror/docker-compose.yml
+++ b/network/registry-mirror/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       REGISTRY_STORAGE_DELETE_ENABLED: "true"
       REGISTRY_STORAGE_CACHE_BLOBDESCRIPTOR: inmemory
     volumes:
-      - registry-data:/var/lib/registry
+      - registry-mirror-data:/var/lib/registry
 
   registry-private:
     image: registry:2
@@ -32,5 +32,5 @@ services:
       - registry-private-data:/var/lib/registry
 
 volumes:
-  registry-data: {}
+  registry-mirror-data: {}
   registry-private-data: {}

--- a/network/scripts/manage-caddy.sh
+++ b/network/scripts/manage-caddy.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=network/scripts/common.sh
 source "$SCRIPT_DIR/common.sh"
 
-CADDY_IMAGE="192.168.1.252:5000/caddy-cloudflare:latest"
+CADDY_IMAGE="192.168.1.252:5001/caddy-cloudflare:latest"
 CADDY_DOCKERFILE="../caddy/Dockerfile"
 
 # Build the custom caddy image locally (fast x86/arm64) and push to the LAN registry.


### PR DESCRIPTION
## Summary

- **Split registry into two services**: pull-through Hub cache on `:5000` (unchanged) and a plain private registry on `:5001` (no `REGISTRY_PROXY_REMOTEURL`) — fixes the broken `caddy-cloudflare` push/pull workflow which was pushing to a proxy-mode registry
- **Update Caddy references** from `:5000` → `:5001` in `manage-caddy.sh` and `caddy/docker-compose.yml`
- **Open UFW port 5001** (LAN only) in network Ansible vars
- **Configure Docker daemon** on `sentinel_trader`, `sonarqube`, and `smart_resume` VMs: registry mirror pointing at `:5000`, log rotation (`json-file`, 10m/3 files), and default address pools

## Test plan

- [ ] `manage-registry-mirror.sh deploy` — both `registry-mirror` and `registry-private` containers come up
- [ ] `manage-caddy.sh rebuild` — image builds and pushes to `:5001` without error
- [ ] On the Pi: `docker pull 192.168.1.252:5001/caddy-cloudflare:latest` succeeds
- [ ] Re-run Ansible `configure.yml` on the Pi — UFW rule for port 5001 applied
- [ ] Re-run `configure_vm.yml` on each compute VM — `/etc/docker/daemon.json` written, Docker restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)