### PR TITLE
feat: expose private registry over HTTPS via registry.mati-lab.online

### DIFF
--- a/network/caddy/Caddyfile
+++ b/network/caddy/Caddyfile
@@ -175,6 +175,15 @@
         }
     }
 
+    @registry host registry.mati-lab.online
+    handle @registry {
+        reverse_proxy http://registry-private:5000 {
+            header_up Host {host}
+            header_up X-Forwarded-Proto https
+            header_up X-Forwarded-Ssl on
+        }
+    }
+
     @sonarqube host sonarqube.mati-lab.online
     handle @sonarqube {
         reverse_proxy 192.168.1.201:9000 {

--- a/network/caddy/docker-compose.yml
+++ b/network/caddy/docker-compose.yml
@@ -4,7 +4,7 @@ networks:
 
 services:
   caddy:
-    image: 192.168.1.252:5001/caddy-cloudflare:latest
+    image: registry.mati-lab.online/caddy-cloudflare:latest
     container_name: caddy
     restart: unless-stopped
     security_opt: [no-new-privileges:true]

--- a/network/scripts/manage-caddy.sh
+++ b/network/scripts/manage-caddy.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=network/scripts/common.sh
 source "$SCRIPT_DIR/common.sh"
 
-CADDY_IMAGE="192.168.1.252:5001/caddy-cloudflare:latest"
+CADDY_IMAGE="registry.mati-lab.online/caddy-cloudflare:latest"
 CADDY_DOCKERFILE="../caddy/Dockerfile"
 
 # Build the custom caddy image locally (fast x86/arm64) and push to the LAN registry.


### PR DESCRIPTION
## Summary

- Add `registry.mati-lab.online` to Caddyfile, proxying to the `registry-private` container on `pihole-net` — valid HTTPS via existing wildcard cert, no `insecure-registries` config needed on any client
- Update `manage-caddy.sh` and `caddy/docker-compose.yml` to use `registry.mati-lab.online` instead of `http://192.168.1.252:5001`

## Test plan

- [ ] Merge + reload Caddy config on Pi → `registry.mati-lab.online` responds
- [ ] `manage-caddy.sh rebuild` — pushes to `registry.mati-lab.online` without TLS errors
- [ ] `docker pull registry.mati-lab.online/caddy-cloudflare:latest` succeeds from any LAN host

🤖 Generated with [Claude Code](https://claude.com/claude-code)