### PR TITLE
fix: disable Loki structured metadata to suppress byte counter errors

### DIFF
--- a/network/loki/loki-config.yml
+++ b/network/loki/loki-config.yml
@@ -27,7 +27,7 @@ schema_config:
         period: 24h
 
 limits_config:
-  allow_structured_metadata: true
+  allow_structured_metadata: false
   # Retain logs for 30 days
   retention_period: 720h
 


### PR DESCRIPTION
## Summary

- Loki 3.x bug: structured metadata byte counter underflows to negative, logging `"negative structured metadata bytes received"` on every Promtail push (~1.4s interval)
- We don't use structured metadata — Docker labels are all handled via `relabel_configs` as regular labels in Promtail — so disabling it is safe and stops the errors

## Test plan

- [ ] Merge + redeploy Loki → errors stop appearing in container logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)