### PR TITLE
fix: enable DIUN watch by default for all containers

### DIFF
--- a/network/diun/docker-compose.yml
+++ b/network/diun/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - "DIUN_WATCH_SCHEDULE=0 */6 * * *"
       - "DIUN_WATCH_JITTER=30s"
       - "DIUN_PROVIDERS_DOCKER=true"
+      - "DIUN_PROVIDERS_DOCKER_WATCHBYDEFAULT=true"
       - "DIUN_NOTIF_NTFY_ENDPOINT=http://ntfy:80"
       - "DIUN_NOTIF_NTFY_TOPIC=diun"
       - "DIUN_NOTIF_NTFY_PRIORITY=3"


### PR DESCRIPTION
## Summary

- Adds `DIUN_PROVIDERS_DOCKER_WATCHBYDEFAULT=true` — without this DIUN only watched itself (the only container with `diun.enable=true`)
- All Pi containers will now be monitored for image updates automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)