### PR TITLE
feat: Grafana alerting provisioning via ntfy /alerts

### DIFF
--- a/network/grafana/.env.example
+++ b/network/grafana/.env.example
@@ -5,3 +5,7 @@ GF_USERS_AUTO_ASSIGN_ORG_ROLE=Admin
 GF_ANALYTICS_REPORTING_ENABLED=false
 GF_SERVER_ROOT_URL=https://grafana.your-domain.example/
 GF_PLUGINS_PREINSTALL=grafana-clock-panel
+
+# ntfy access token for alert notifications (required — ntfy uses deny-all default access)
+# Generate a token: ntfy token add --label=grafana <username>
+NTFY_ALERTS_TOKEN=

--- a/network/grafana/provisioning/alerting/contact-points.yml
+++ b/network/grafana/provisioning/alerting/contact-points.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: ntfy-alerts
+    receivers:
+      - uid: ntfy-alerts
+        type: webhook
+        settings:
+          url: http://ntfy:80/alerts
+          httpMethod: POST
+          title: "{{ template \"default.title\" . }}"
+          message: "{{ template \"default.message\" . }}"
+        disableResolveMessage: false

--- a/network/grafana/provisioning/alerting/contact-points.yml
+++ b/network/grafana/provisioning/alerting/contact-points.yml
@@ -9,6 +9,9 @@ contactPoints:
         settings:
           url: http://ntfy:80/alerts
           httpMethod: POST
+          httpHeaderName1: Authorization
           title: "{{ template \"default.title\" . }}"
           message: "{{ template \"default.message\" . }}"
+        secureSettings:
+          httpHeaderValue1: Bearer $__env{NTFY_ALERTS_TOKEN}
         disableResolveMessage: false

--- a/network/grafana/provisioning/alerting/notification-policy.yml
+++ b/network/grafana/provisioning/alerting/notification-policy.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: ntfy-alerts
+    group_by: [alertname]
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/network/grafana/provisioning/alerting/rules.yml
+++ b/network/grafana/provisioning/alerting/rules.yml
@@ -148,7 +148,7 @@ groups:
             model:
               expr: |
                 sum by (container) (
-                  rate({job="docker"} |~ "(?i)error" [5m])
+                  rate({job="docker"} |~ "(?i)error"[5m])
                 )
               instant: true
               intervalMs: 1000

--- a/network/grafana/provisioning/alerting/rules.yml
+++ b/network/grafana/provisioning/alerting/rules.yml
@@ -1,0 +1,184 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: infrastructure
+    folder: Alerts
+    interval: 1m
+    rules:
+      - uid: disk-usage-high
+        title: Disk Usage High
+        condition: C
+        data:
+          - refId: A
+            datasourceUid: prometheus-mati-lab
+            model:
+              expr: |
+                (
+                  node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs", mountpoint="/"}
+                  - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs", mountpoint="/"}
+                ) / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs", mountpoint="/"} * 100
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params: [80]
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: Disk usage above 80%
+          description: "Disk usage on {{ $labels.instance }} is {{ printf \"%.0f\" $values.A.Value }}%"
+        labels:
+          severity: warning
+
+      - uid: iowait-high
+        title: IO Wait High
+        condition: C
+        data:
+          - refId: A
+            datasourceUid: prometheus-mati-lab
+            model:
+              expr: |
+                avg by (instance) (
+                  rate(node_cpu_seconds_total{mode="iowait"}[5m])
+                ) * 100
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params: [50]
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: IO wait above 50%
+          description: "IO wait on {{ $labels.instance }} is {{ printf \"%.0f\" $values.A.Value }}% — possible storage saturation"
+        labels:
+          severity: warning
+
+      - uid: memory-usage-high
+        title: Memory Usage High
+        condition: C
+        data:
+          - refId: A
+            datasourceUid: prometheus-mati-lab
+            model:
+              expr: |
+                (
+                  1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)
+                ) * 100
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params: [90]
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: Memory usage above 90%
+          description: "Memory usage on {{ $labels.instance }} is {{ printf \"%.0f\" $values.A.Value }}%"
+        labels:
+          severity: critical
+
+      - uid: container-errors
+        title: Container Error Rate High
+        condition: C
+        data:
+          - refId: A
+            datasourceUid: loki-sentinel
+            model:
+              expr: |
+                sum by (container) (
+                  rate({job="docker"} |~ "(?i)error" [5m])
+                )
+              instant: true
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: A
+          - refId: C
+            datasourceUid: __expr__
+            model:
+              conditions:
+                - evaluator:
+                    params: [0.1]
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: [A]
+                  reducer:
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: __expr__
+              expression: A
+              refId: C
+              type: threshold
+        noDataState: NoData
+        execErrState: Error
+        for: 5m
+        annotations:
+          summary: Container error rate elevated
+          description: "Container {{ $labels.container }} is logging errors at {{ printf \"%.2f\" $values.A.Value }} errors/sec"
+        labels:
+          severity: warning

--- a/network/grafana/provisioning/datasources/loki.yml
+++ b/network/grafana/provisioning/datasources/loki.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: loki-sentinel
+    uid: loki-sentinel
     type: loki
     url: http://loki:3100
     access: proxy

--- a/network/grafana/provisioning/datasources/prometheus.yml
+++ b/network/grafana/provisioning/datasources/prometheus.yml
@@ -2,6 +2,7 @@ apiVersion: 1
 
 datasources:
   - name: prometheus-mati-lab
+    uid: prometheus-mati-lab
     type: prometheus
     url: http://prometheus:9090
     access: proxy


### PR DESCRIPTION
## Summary

- Adds `network/grafana/provisioning/alerting/` with three files that provision Grafana Unified Alerting on container start, no manual UI setup needed
- **contact-points.yml** — ntfy webhook contact point targeting `http://ntfy:80/alerts`
- **notification-policy.yml** — default route to ntfy, repeat every 4 h
- **rules.yml** — four alert rules evaluated every 1 min, fire after 5 min:
  - **Disk Usage High** (>80%) — via Prometheus `node_filesystem_*` metrics
  - **IO Wait High** (>50%) — via `node_cpu_seconds_total{mode="iowait"}`; catches SD card saturation
  - **Memory Usage High** (>90%) — via `node_memory_MemAvailable_bytes`
  - **Container Error Rate** (>0.1 err/s) — via Loki `{job="docker"}` log stream
- Adds stable `uid` fields to both datasource YAMLs so alert rules can reference them by ID

## Test plan

- [ ] Merge + run `manage-grafana.sh update` on the Pi
- [ ] Open Grafana → Alerting → Alert rules — verify all 4 rules appear in folder `Alerts`
- [ ] Open Alerting → Contact points — verify `ntfy-alerts` is listed
- [ ] Open Alerting → Notification policies — verify default route points to `ntfy-alerts`
- [ ] Optionally: temporarily lower a threshold to trigger a test notification on `/alerts` topic

🤖 Generated with [Claude Code](https://claude.com/claude-code)