### PR TITLE
fix: add relativeTimeRange to alert rule queries

### DIFF
--- a/network/grafana/provisioning/alerting/rules.yml
+++ b/network/grafana/provisioning/alerting/rules.yml
@@ -12,6 +12,9 @@ groups:
         data:
           - refId: A
             datasourceUid: prometheus-mati-lab
+            relativeTimeRange:
+              from: 600
+              to: 0
             model:
               expr: |
                 (
@@ -24,6 +27,9 @@ groups:
               refId: A
           - refId: C
             datasourceUid: __expr__
+            relativeTimeRange:
+              from: 0
+              to: 0
             model:
               conditions:
                 - evaluator:
@@ -57,6 +63,9 @@ groups:
         data:
           - refId: A
             datasourceUid: prometheus-mati-lab
+            relativeTimeRange:
+              from: 600
+              to: 0
             model:
               expr: |
                 avg by (instance) (
@@ -68,6 +77,9 @@ groups:
               refId: A
           - refId: C
             datasourceUid: __expr__
+            relativeTimeRange:
+              from: 0
+              to: 0
             model:
               conditions:
                 - evaluator:
@@ -101,6 +113,9 @@ groups:
         data:
           - refId: A
             datasourceUid: prometheus-mati-lab
+            relativeTimeRange:
+              from: 600
+              to: 0
             model:
               expr: |
                 (
@@ -112,6 +127,9 @@ groups:
               refId: A
           - refId: C
             datasourceUid: __expr__
+            relativeTimeRange:
+              from: 0
+              to: 0
             model:
               conditions:
                 - evaluator:
@@ -145,6 +163,9 @@ groups:
         data:
           - refId: A
             datasourceUid: loki-sentinel
+            relativeTimeRange:
+              from: 600
+              to: 0
             model:
               expr: |
                 sum by (container) (
@@ -156,6 +177,9 @@ groups:
               refId: A
           - refId: C
             datasourceUid: __expr__
+            relativeTimeRange:
+              from: 0
+              to: 0
             model:
               conditions:
                 - evaluator:


### PR DESCRIPTION
## Summary

Grafana requires a `relativeTimeRange` on every `data` query entry in provisioned alert rules — without it the field defaults to `from:0, to:0` which is an invalid relative time range and causes the entire provisioning service to crash on startup.

- Datasource queries (Prometheus/Loki): `from: 600, to: 0` (10 min lookback)
- `__expr__` reduce/threshold nodes: `from: 0, to: 0` (correct for expressions)

Also required a fresh Grafana volume wipe to resolve a separate issue where adding explicit `uid` fields to existing datasource YAMLs caused a UID mismatch against the old database entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)