### PR TITLE
fix: use ${VAR} interpolation for ntfy token in contact point

### DIFF
--- a/network/grafana/provisioning/alerting/contact-points.yml
+++ b/network/grafana/provisioning/alerting/contact-points.yml
@@ -10,8 +10,7 @@ contactPoints:
           url: http://ntfy:80/alerts
           httpMethod: POST
           httpHeaderName1: Authorization
+          httpHeaderValue1: "Bearer ${NTFY_ALERTS_TOKEN}"
           title: "{{ template \"default.title\" . }}"
           message: "{{ template \"default.message\" . }}"
-        secureSettings:
-          httpHeaderValue1: Bearer $__env{NTFY_ALERTS_TOKEN}
         disableResolveMessage: false


### PR DESCRIPTION
## Summary

`secureSettings` in Grafana contact point provisioning does not expand environment variables — the literal string `Bearer $__env{NTFY_ALERTS_TOKEN}` was being sent as the Authorization header, causing ntfy to return 403 Forbidden.

Fix: move `httpHeaderValue1` to `settings` and use `${NTFY_ALERTS_TOKEN}` which Grafana does expand during provisioning load.

Confirmed via `docker logs grafana`: `webhook response status 403 Forbidden` before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)