### PR TITLE
feat: clean ntfy notification templates for Grafana alerts

### DIFF
--- a/network/grafana/provisioning/alerting/contact-points.yml
+++ b/network/grafana/provisioning/alerting/contact-points.yml
@@ -10,8 +10,8 @@ contactPoints:
           url: http://ntfy:80/alerts
           httpMethod: POST
           httpHeaderName1: Authorization
-          title: "{{ template \"default.title\" . }}"
-          message: "{{ template \"default.message\" . }}"
+          title: "{{ template \"mati-lab.title\" . }}"
+          message: "{{ template \"mati-lab.message\" . }}"
         secureSettings:
           httpHeaderValue1: "Bearer ${NTFY_ALERTS_TOKEN}"
         disableResolveMessage: false

--- a/network/grafana/provisioning/alerting/templates.yml
+++ b/network/grafana/provisioning/alerting/templates.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+templates:
+  - orgId: 1
+    name: mati-lab.title
+    template: "{{ define \"mati-lab.title\" }}{{ if eq .Status \"resolved\" }}✅ {{ (index .Alerts 0).Labels.alertname }} resolved{{ else }}{{ $n := len .Alerts }}{{ if eq $n 1 }}{{ $a := index .Alerts 0 }}{{ if eq $a.Labels.severity \"critical\" }}🔴{{ else }}⚠️{{ end }} {{ $a.Labels.alertname }}{{ else }}⚠️ {{ $n }} alerts firing{{ end }}{{ end }}{{ end }}"
+
+  - orgId: 1
+    name: mati-lab.message
+    template: "{{ define \"mati-lab.message\" }}{{ range $i, $a := .Alerts }}{{ if $i }}\n{{ end }}{{ if $a.Annotations.description }}{{ $a.Annotations.description }}{{ else }}{{ $a.Annotations.summary }}{{ end }}{{ end }}{{ end }}"


### PR DESCRIPTION
## What

Replaces Grafana's verbose `default.title`/`default.message` templates (which dump raw JSON) with compact custom templates.

**Before** (ntfy message body = 3.5 KB raw JSON):
```
[FIRING:2] DatasourceError (Alerts warning)
**Firing**
Value: [no value]
Labels:
 - alertname = DatasourceError
 - grafana_folder = Alerts
 - rulename = Disk Usage High
 ...
Source: https://...
Silence: https://...
```

**After**:
- Title: `⚠️ Disk Usage High` / `🔴 Memory Usage High` / `✅ ... resolved` / `⚠️ 3 alerts firing`
- Message: `Disk usage on 192.168.1.252:9100 is 87%`

## Design

Single generic template — no per-rule maintenance needed:
- Emoji from severity (`critical` → 🔴, else ⚠️) or resolved (✅)
- Title = `alertname` label (or count for grouped alerts)
- Message = `description` annotation (pre-rendered with metric value), fallback to `summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)