### PR TITLE
refactor(smart-resume): switch to registry-based deploy

### DIFF
--- a/compute/smart_resume_vm/group_vars/all/vars.yml
+++ b/compute/smart_resume_vm/group_vars/all/vars.yml
@@ -32,3 +32,5 @@ docker_log_max_file: "3"
 # App
 app_repo_path: "/home/gooral/Projects/smart-resume"
 app_remote_path: "/opt/smart-resume"
+registry_image_api: "registry.mati-lab.online/smart-resume-api:latest"
+registry_image_web: "registry.mati-lab.online/smart-resume-web:latest"

--- a/compute/smart_resume_vm/playbooks/deploy_app.yml
+++ b/compute/smart_resume_vm/playbooks/deploy_app.yml
@@ -26,6 +26,7 @@
       ansible.builtin.command:
         cmd: >-
           docker buildx build --push
+          --platform linux/amd64
           -t {{ registry_image_api }}
           apps/api
         chdir: "{{ app_repo_path }}"
@@ -37,6 +38,7 @@
       ansible.builtin.command:
         cmd: >-
           docker buildx build --push
+          --platform linux/amd64
           -t {{ registry_image_web }}
           --build-arg PUBLIC_TURNSTILE_SITE_KEY={{ vault_turnstile_site_key }}
           apps/web

--- a/compute/smart_resume_vm/playbooks/deploy_app.yml
+++ b/compute/smart_resume_vm/playbooks/deploy_app.yml
@@ -22,13 +22,28 @@
       run_once: true
       changed_when: false
 
-    - name: Run frontend E2E tests (Playwright)
+    - name: Build and push API image
       ansible.builtin.command:
-        cmd: yarn test:e2e --timeout=30000
-        chdir: "{{ app_repo_path }}/apps/web"
+        cmd: >-
+          docker buildx build --push
+          -t {{ registry_image_api }}
+          apps/api
+        chdir: "{{ app_repo_path }}"
       delegate_to: localhost
       run_once: true
-      changed_when: false
+      changed_when: true
+
+    - name: Build and push web image
+      ansible.builtin.command:
+        cmd: >-
+          docker buildx build --push
+          -t {{ registry_image_web }}
+          --build-arg PUBLIC_TURNSTILE_SITE_KEY={{ vault_turnstile_site_key }}
+          apps/web
+        chdir: "{{ app_repo_path }}"
+      delegate_to: localhost
+      run_once: true
+      changed_when: true
 
   tasks:
     - name: Create app directory
@@ -39,43 +54,23 @@
         mode: "0755"
       become: true
 
-    - name: Sync project files
-      ansible.posix.synchronize:
-        src:  "{{ app_repo_path }}/"
-        dest: "{{ app_remote_path }}/"
-        rsync_opts:
-          - "--exclude=.git"
-          - "--exclude=node_modules"
-          - "--exclude=.venv"
-          - "--exclude=__pycache__"
-          - "--exclude=apps/web/dist"
-          - "--exclude=apps/web/.astro"
-          - "--exclude=apps/api/src/app/resources/docs"
-          - "--exclude=.env"
-          - "--delete"
-
-    - name: Write .env
+    - name: Write docker-compose.yml
       ansible.builtin.template:
-        src:  ../templates/env.j2
+        src: ../templates/docker-compose.yml.j2
+        dest: "{{ app_remote_path }}/docker-compose.yml"
+        owner: "{{ vm_ssh_user }}"
+        mode: "0644"
+
+    - name: Write API .env
+      ansible.builtin.template:
+        src: ../templates/env.j2
         dest: "{{ app_remote_path }}/.env"
         owner: "{{ vm_ssh_user }}"
         mode: "0600"
 
-    - name: Write apps/web/.env
-      ansible.builtin.template:
-        src:  ../templates/web.env.j2
-        dest: "{{ app_remote_path }}/apps/web/.env"
-        owner: "{{ vm_ssh_user }}"
-        mode: "0600"
-
-    - name: Build and start containers
+    - name: Pull latest images and start stack
       community.docker.docker_compose_v2:
         project_src: "{{ app_remote_path }}"
-        build: always
+        pull: always
         state: present
-        pull: missing
         remove_orphans: true
-        profiles:
-          - prod
-      environment:
-        PUBLIC_TURNSTILE_SITE_KEY: "{{ vault_turnstile_site_key }}"

--- a/compute/smart_resume_vm/templates/docker-compose.yml.j2
+++ b/compute/smart_resume_vm/templates/docker-compose.yml.j2
@@ -1,0 +1,15 @@
+services:
+  web:
+    image: "{{ registry_image_web }}"
+    container_name: smart-resume-web
+    restart: unless-stopped
+    ports:
+      - "4321:80"
+
+  api:
+    image: "{{ registry_image_api }}"
+    container_name: smart-resume-api
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    env_file: .env

--- a/compute/smart_resume_vm/templates/docker-compose.yml.j2
+++ b/compute/smart_resume_vm/templates/docker-compose.yml.j2
@@ -4,12 +4,10 @@ services:
     container_name: smart-resume-web
     restart: unless-stopped
     ports:
-      - "4321:80"
+      - "80:80"
 
   api:
     image: "{{ registry_image_api }}"
     container_name: smart-resume-api
     restart: unless-stopped
-    ports:
-      - "8000:8000"
     env_file: .env

--- a/compute/smart_resume_vm/templates/web.env.j2
+++ b/compute/smart_resume_vm/templates/web.env.j2
@@ -1,1 +1,0 @@
-PUBLIC_TURNSTILE_SITE_KEY={{ vault_turnstile_site_key }}

--- a/network/caddy/Caddyfile
+++ b/network/caddy/Caddyfile
@@ -35,7 +35,7 @@
 
     @smart-resume host smart-resume.mati-lab.online
     handle @smart-resume {
-        reverse_proxy 192.168.1.200:4321
+        reverse_proxy 192.168.1.200:80
     }
 
     @proxmox host proxmox.mati-lab.online


### PR DESCRIPTION
## Summary

- Builds smart-resume images locally and pushes to `registry.mati-lab.online` — aligns with restorate and caddy
- VM pulls pre-built images instead of rsyncing source and building on the VM
- Drops `web.env.j2`: `PUBLIC_TURNSTILE_SITE_KEY` was always a build-time ARG baked into the bundle, not a runtime var for nginx; now passed via `--build-arg` during local build
- Adds `docker-compose.yml.j2` template with `image:` refs (app repo's `compose.yml` unchanged — still works for local dev)
- Drops E2E Playwright pre-task from deploy (belongs in CI, not deploy gate)

## Deploy flow (after)

```
local: docker buildx build --push → registry.mati-lab.online/smart-resume-{api,web}:latest
VM:    docker compose pull → docker compose up
```

## Test plan

- [ ] `make deploy` builds and pushes both images, VM pulls and starts stack
- [ ] `smart-resume.mati-lab.online` still reachable with correct Turnstile widget