### PR TITLE
fix(smart-resume): remove legacy compose.yml on deploy

### DIFF
--- a/compute/smart_resume_vm/playbooks/deploy_app.yml
+++ b/compute/smart_resume_vm/playbooks/deploy_app.yml
@@ -56,6 +56,11 @@
         mode: "0755"
       become: true
 
+    - name: Remove legacy compose.yml left by rsync-based deploys
+      ansible.builtin.file:
+        path: "{{ app_remote_path }}/compose.yml"
+        state: absent
+
     - name: Write docker-compose.yml
       ansible.builtin.template:
         src: ../templates/docker-compose.yml.j2

--- a/compute/smart_resume_vm/playbooks/deploy_app.yml
+++ b/compute/smart_resume_vm/playbooks/deploy_app.yml
@@ -60,6 +60,7 @@
       ansible.builtin.file:
         path: "{{ app_remote_path }}/compose.yml"
         state: absent
+      become: true
 
     - name: Write docker-compose.yml
       ansible.builtin.template:


### PR DESCRIPTION
`compose.yml` left by the old rsync-based deploys takes precedence over `docker-compose.yml` in Docker Compose's file discovery order, so the wrong file was being used on first deploy with the new strategy.

Adds an idempotent cleanup task that removes it before starting the stack. No-op on fresh VMs.