### PR TITLE
fix(grafana): include container/instance in alert title and message

### DIFF
--- a/network/grafana/provisioning/alerting/templates.yml
+++ b/network/grafana/provisioning/alerting/templates.yml
@@ -3,8 +3,8 @@ apiVersion: 1
 templates:
   - orgId: 1
     name: mati-lab.title
-    template: "{{ define \"mati-lab.title\" }}{{ if eq .Status \"resolved\" }}✅ {{ (index .Alerts 0).Labels.alertname }} resolved{{ else }}{{ $n := len .Alerts }}{{ if eq $n 1 }}{{ $a := index .Alerts 0 }}{{ if eq $a.Labels.severity \"critical\" }}🔴{{ else }}⚠️{{ end }} {{ $a.Labels.alertname }}{{ else }}⚠️ {{ $n }} alerts firing{{ end }}{{ end }}{{ end }}"
+    template: "{{ define \"mati-lab.title\" }}{{ $a := index .Alerts 0 }}{{ $name := or $a.Labels.alertname \"Alert\" }}{{ if eq .Status \"resolved\" }}✅ {{ $name }} resolved{{ else }}{{ if eq $a.Labels.severity \"critical\" }}🔴{{ else }}⚠️{{ end }} {{ $name }}{{ if gt (len .Alerts) 1 }} ({{ len .Alerts }}){{ else if $a.Labels.container }} — {{ $a.Labels.container }}{{ else if $a.Labels.instance }} — {{ $a.Labels.instance }}{{ end }}{{ end }}{{ end }}"
 
   - orgId: 1
     name: mati-lab.message
-    template: "{{ define \"mati-lab.message\" }}{{ range $i, $a := .Alerts }}{{ if $i }}\n{{ end }}{{ if $a.Annotations.description }}{{ $a.Annotations.description }}{{ else }}{{ $a.Annotations.summary }}{{ end }}{{ end }}{{ end }}"
+    template: "{{ define \"mati-lab.message\" }}{{ range $i, $a := .Alerts }}{{ if $i }}\n{{ end }}{{ if $a.Labels.container }}[{{ $a.Labels.container }}] {{ end }}{{ if $a.Annotations.description }}{{ $a.Annotations.description }}{{ else }}{{ $a.Annotations.summary }}{{ end }}{{ end }}{{ end }}"


### PR DESCRIPTION
## Summary
- Title now shows `⚠️ Container Error Rate High — caddy` instead of `[no title]` when `alertname` is missing
- Adds `[container]` prefix to message body for per-container alerts
- Falls back to `"Alert"` when `alertname` label is absent (prevents empty title)
- Uses `instance` as secondary fallback in title when `container` is not set

## Test plan
- [ ] Merge and deploy to server (`docker compose restart grafana` under `network/`)
- [ ] Trigger or wait for next container alert to verify title and message format in ntfy

🤖 Generated with [Claude Code](https://claude.com/claude-code)