### PR TITLE
fix(restorate-vm): fix Valkey password mismatch and conf permissions

### DIFF
--- a/compute/restorate_vm/playbooks/deploy_app.yml
+++ b/compute/restorate_vm/playbooks/deploy_app.yml
@@ -40,10 +40,12 @@
         mode: "0755"
       become: true
 
-    - name: Sync valkey.conf
-      ansible.posix.synchronize:
-        src: "{{ app_repo_path }}/valkey.conf"
+    - name: Write valkey.conf
+      ansible.builtin.template:
+        src: ../templates/valkey.conf.j2
         dest: "{{ app_remote_path }}/valkey.conf"
+        owner: "{{ vm_ssh_user }}"
+        mode: "0644"
 
     - name: Write docker-compose.yml
       ansible.builtin.template:

--- a/compute/restorate_vm/templates/valkey.conf.j2
+++ b/compute/restorate_vm/templates/valkey.conf.j2
@@ -1,0 +1,8 @@
+bind 0.0.0.0
+port 6379
+protected-mode yes
+
+save 60 1
+dir /data
+
+requirepass {{ valkey_password }}


### PR DESCRIPTION
## Summary

- Replaces `Sync valkey.conf` (rsync of hardcoded dev config) with a Jinja2 template that injects `{{ valkey_password }}` from the Ansible vault
- Sets `mode: 0644` so the Valkey container (running as a non-root user) can read the config file
- Fixes `WRONGPASS` auth failures between the API and Valkey on first deployment

## Test plan

- [x] `make provision` from scratch — VM created, configured, and app deployed cleanly
- [x] All 5 containers healthy: `restorate-api`, `restorate-web`, `restorate-caddy`, `restorate-db`, `restorate-valkey`
- [x] Frontend returns HTTP 200 at `http://192.168.1.203/`
- [x] API starts and connects to both Postgres and Valkey successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)