### PR TITLE
fix(caddy): fix Connect-RPC routing and align security headers

### DIFF
--- a/compute/restorate_vm/templates/Caddyfile.j2
+++ b/compute/restorate_vm/templates/Caddyfile.j2
@@ -1,6 +1,27 @@
+{
+    # Structured JSON access log (written to stdout, picked up by Docker)
+    log default {
+        output stdout
+        format json
+        level INFO
+    }
+}
+
 :80 {
+    # Security headers
+    header {
+        X-Content-Type-Options "nosniff"
+        X-Frame-Options "DENY"
+        Referrer-Policy "strict-origin-when-cross-origin"
+        -Server
+    }
+
+    # Compress responses
+    encode zstd gzip
+
     # Connect-RPC service routes — pattern: /<pkg>.<version>.<ServiceName>/
-    @connect_rpc path_regexp ^/[a-z][a-z0-9]*\.[a-z][a-z0-9]*\.[A-Z]
+    # pkg names can contain underscores (e.g. google_maps)
+    @connect_rpc path_regexp ^/[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*\.[A-Z]
     handle @connect_rpc {
         reverse_proxy api:3001
     }

--- a/compute/restorate_vm/templates/Caddyfile.j2
+++ b/compute/restorate_vm/templates/Caddyfile.j2
@@ -8,13 +8,8 @@
 }
 
 :80 {
-    # Security headers
-    header {
-        X-Content-Type-Options "nosniff"
-        X-Frame-Options "DENY"
-        Referrer-Policy "strict-origin-when-cross-origin"
-        -Server
-    }
+    # Hide the server identity — infrastructure concern, not the app's job
+    header -Server
 
     # Compress responses
     encode zstd gzip

--- a/network/scripts/manage-caddy.sh
+++ b/network/scripts/manage-caddy.sh
@@ -45,8 +45,8 @@ update() {
   log "Updating $SERVICE_NAME (pull only, no rebuild)"
   sync_from_github
   copy_env_file "../$SERVICE_NAME"
+  compose_cmd pull  # pull while Caddy is still up so registry.mati-lab.online is reachable
   compose_cmd down
-  compose_cmd pull
   compose_cmd up -d
 }
 


### PR DESCRIPTION
## Summary
- Fix \`path_regexp\` to allow underscores in proto package names (\`google_maps\` was returning 404)
- Remove app-owned security headers from Caddyfile (now handled by SvelteKit and Go API)
- Add JSON access logging, compression, and \`-Server\` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)