### PR TITLE
fix(deploy): REST routing, Prometheus port, and Loki log shipping

### DIFF
--- a/compute/restorate_vm/group_vars/all/vars.yml
+++ b/compute/restorate_vm/group_vars/all/vars.yml
@@ -26,6 +26,7 @@ vm_ssh_key_path: "~/.ssh/id_ed25519.pub"
 
 # Docker
 docker_registry_mirror: "http://192.168.1.252:5000"
+loki_push_url: "http://192.168.1.252:3100/loki/api/v1/push"
 docker_log_max_size: "10m"
 docker_log_max_file: "3"
 

--- a/compute/restorate_vm/playbooks/deploy_app.yml
+++ b/compute/restorate_vm/playbooks/deploy_app.yml
@@ -61,6 +61,13 @@
         owner: "{{ vm_ssh_user }}"
         mode: "0644"
 
+    - name: Write Promtail config
+      ansible.builtin.template:
+        src: ../templates/promtail-config.yml.j2
+        dest: "{{ app_remote_path }}/promtail-config.yml"
+        owner: "{{ vm_ssh_user }}"
+        mode: "0644"
+
     - name: Write API .env
       ansible.builtin.template:
         src: ../templates/api.env.j2

--- a/compute/restorate_vm/templates/Caddyfile.j2
+++ b/compute/restorate_vm/templates/Caddyfile.j2
@@ -14,6 +14,11 @@
     # Compress responses
     encode zstd gzip
 
+    # Block Prometheus metrics from public access
+    handle /metrics {
+        respond 404
+    }
+
     # Connect-RPC service routes — pattern: /<pkg>.<version>.<ServiceName>/
     # pkg names can contain underscores (e.g. google_maps)
     @connect_rpc path_regexp ^/[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*\.[A-Z]
@@ -22,7 +27,16 @@
     }
 
     # REST API routes
-    handle /api/* {
+    handle /place-photo {
+        reverse_proxy api:3001
+    }
+    handle /health {
+        reverse_proxy api:3001
+    }
+    handle /export/reviews {
+        reverse_proxy api:3001
+    }
+    handle /admin/invite-secret {
         reverse_proxy api:3001
     }
 

--- a/compute/restorate_vm/templates/docker-compose.yml.j2
+++ b/compute/restorate_vm/templates/docker-compose.yml.j2
@@ -42,6 +42,8 @@ services:
         condition: service_healthy
       valkey:
         condition: service_healthy
+    ports:
+      - "3001:3001"  # Prometheus scrapes this directly; not routed through Caddy
     networks:
       - restorate-net
 

--- a/compute/restorate_vm/templates/docker-compose.yml.j2
+++ b/compute/restorate_vm/templates/docker-compose.yml.j2
@@ -71,9 +71,23 @@ services:
     networks:
       - restorate-net
 
+  promtail:
+    image: grafana/promtail:3.5.0
+    container_name: restorate-promtail
+    restart: unless-stopped
+    command: -config.file=/etc/promtail/promtail-config.yml
+    volumes:
+      - ./promtail-config.yml:/etc/promtail/promtail-config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - promtail-positions:/var/lib/promtail
+    security_opt: [no-new-privileges:true]
+    networks:
+      - restorate-net
+
 volumes:
   pgdata:
   valkeydata:
+  promtail-positions:
 
 networks:
   restorate-net:

--- a/compute/restorate_vm/templates/promtail-config.yml.j2
+++ b/compute/restorate_vm/templates/promtail-config.yml.j2
@@ -1,0 +1,29 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /var/lib/promtail/positions.yaml
+
+clients:
+  - url: {{ loki_push_url }}
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 10s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        target_label: compose_project
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_service']
+        target_label: compose_service
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: container
+      - target_label: host
+        replacement: restorate-vm
+      # Only forward containers belonging to this compose project
+      - source_labels: ['__meta_docker_container_label_com_docker_compose_project']
+        regex: restorate
+        action: keep


### PR DESCRIPTION
## Summary
- Fix Caddy routing: add explicit routes for /place-photo, /health, /export/reviews, /admin/invite-secret (were all falling through to SvelteKit 404); block /metrics from public access
- Expose API port 3001 to host so Prometheus on network-pi can scrape 192.168.1.203:3001/metrics
- Add Promtail sidecar — Loki dashboard panels querying {compose_project="restorate"} had no data; Loki's port 3100 on 192.168.1.252 was already open for remote VMs, just never wired up

## Test plan
- [ ] /place-photo returns API response (not SvelteKit HTML 404)
- [ ] Prometheus scrapes 192.168.1.203:3001/metrics successfully
- [ ] Loki dashboard panels (Log Stream, Error Count, Log Volume) show restorate container logs
- [ ] /metrics returns 404 via Caddy (not publicly accessible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)