### PR TITLE
fix(restorate-vm): rename VM to restorate and bump RAM to 4 GiB

### DIFF
--- a/compute/restorate_vm/group_vars/all/vars.yml
+++ b/compute/restorate_vm/group_vars/all/vars.yml
@@ -10,7 +10,7 @@ vm_id: 105
 vm_name: "restorate"
 vm_template_id: 9000
 vm_cores: 2
-vm_memory_mb: 2048
+vm_memory_mb: 4096
 vm_disk_size: "20G"
 vm_storage: "local-lvm"
 

--- a/compute/restorate_vm/inventory/hosts.yml
+++ b/compute/restorate_vm/inventory/hosts.yml
@@ -1,5 +1,7 @@
 all:
   hosts:
+    localhost:
+      ansible_connection: local
     restorate:
       ansible_host: "192.168.1.203"
       ansible_user: debian

--- a/compute/restorate_vm/playbooks/create_vm.yml
+++ b/compute/restorate_vm/playbooks/create_vm.yml
@@ -27,6 +27,7 @@
         api_token_secret: "{{ proxmox_api_token_secret }}"
         node:   "{{ proxmox_node }}"
         vmid:   "{{ vm_id }}"
+        name:   "{{ vm_name }}"
         cores:  "{{ vm_cores }}"
         memory: "{{ vm_memory_mb }}"
         ipconfig:


### PR DESCRIPTION
## Summary
- Renames qemu/105 from `Copy-of-VM-debian12-cloud` to `restorate` by adding `name` param to the configure cloud-init task
- Bumps `vm_memory_mb` from 2048 to 4096 (2 GiB → 4 GiB)
- Adds `localhost` to inventory so `create_vm.yml` (which runs against `hosts: localhost`) can actually execute

## Test plan
- [ ] VM 105 shows name `restorate` in Proxmox UI
- [ ] VM 105 shows 4 GiB memory after reboot

🤖 Generated with [Claude Code](https://claude.com/claude-code)