### PR TITLE
feat(restorate-vm): database operations in Makefile

### DIFF
--- a/compute/restorate_vm/.gitignore
+++ b/compute/restorate_vm/.gitignore
@@ -1,1 +1,2 @@
 group_vars/all/vault.yml
+backups/

--- a/compute/restorate_vm/Makefile
+++ b/compute/restorate_vm/Makefile
@@ -38,10 +38,11 @@ deploy:
 ##            Backups are portable across Postgres minor versions via pg_restore.
 db-backup:
 	@mkdir -p $(BACKUP_DIR)
-	@TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
+	@set -e; \
+	 TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
 	 OUTFILE=$(BACKUP_DIR)/restorate_$$TIMESTAMP.dump; \
 	 echo "Backing up to $$OUTFILE ..."; \
-	 $(SSH) "docker exec $(DB_CONTAINER) pg_dump -U $(DB_USER) -Fc $(DB_NAME)" > $$OUTFILE; \
+	 $(SSH) "docker exec $(DB_CONTAINER) pg_dump -U $(DB_USER) -Fc $(DB_NAME)" > $$OUTFILE && \
 	 echo "Done — $$(du -sh $$OUTFILE | cut -f1)"
 
 ## db-restore FILE=<path>: Restore a dump created by db-backup.
@@ -77,8 +78,8 @@ db-logs:
 	$(SSH_TTY) "docker logs -f --tail=100 $(DB_CONTAINER)"
 
 ## db-psql-exec SQL="<query>": Run a one-shot SQL statement (no TTY needed, good for scripts).
-##   Note: intended for simple queries; for complex SQL use db-shell instead.
+##   SQL is passed via stdin so quoting/special characters are handled safely.
 ##   Example: make db-psql-exec SQL="SELECT count(*) FROM users"
 db-psql-exec:
 	@test -n "$(SQL)" || { echo "Usage: make db-psql-exec SQL=\"<query>\""; exit 1; }
-	$(SSH) "docker exec $(DB_CONTAINER) psql -U $(DB_USER) -d $(DB_NAME) -v ON_ERROR_STOP=1 -X -c '$(SQL)'"
+	@printf '%s' '$(SQL)' | $(SSH) "docker exec -i $(DB_CONTAINER) psql -U $(DB_USER) -d $(DB_NAME) -v ON_ERROR_STOP=1 -X -f -"

--- a/compute/restorate_vm/Makefile
+++ b/compute/restorate_vm/Makefile
@@ -40,7 +40,7 @@ db-backup:
 	@mkdir -p $(BACKUP_DIR)
 	@set -e; \
 	 TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
-	 OUTFILE=$(BACKUP_DIR)/restorate_$$TIMESTAMP.dump; \
+	 OUTFILE=$(BACKUP_DIR)/$(DB_NAME)_$$TIMESTAMP.dump; \
 	 TMPFILE=$$OUTFILE.tmp; \
 	 echo "Backing up to $$OUTFILE ..."; \
 	 $(SSH) "docker exec $(DB_CONTAINER) pg_dump -U $(DB_USER) -Fc $(DB_NAME)" > $$TMPFILE && \

--- a/compute/restorate_vm/Makefile
+++ b/compute/restorate_vm/Makefile
@@ -1,4 +1,20 @@
-.PHONY: provision configure deploy install-deps
+.PHONY: provision configure deploy install-deps \
+        db-backup db-restore db-clean db-shell db-logs db-psql-exec
+
+# ── SSH / container config ────────────────────────────────────────────────────
+SSH_KEY  := ~/.ssh/id_ed25519
+SSH_HOST := debian@192.168.1.203
+SSH      := ssh -i $(SSH_KEY) -o StrictHostKeyChecking=no $(SSH_HOST)
+SSH_TTY  := ssh -t -i $(SSH_KEY) -o StrictHostKeyChecking=no $(SSH_HOST)
+
+DB_CONTAINER := restorate-db
+DB_NAME      := restorate
+DB_USER      := restorate
+APP_DIR      := /opt/restorate
+
+BACKUP_DIR := ./backups
+
+# ── Provisioning ──────────────────────────────────────────────────────────────
 
 install-deps:
 	ansible-galaxy collection install -r requirements.yml
@@ -11,3 +27,53 @@ configure:
 
 deploy:
 	ansible-playbook playbooks/deploy_app.yml
+
+# ── Database operations ───────────────────────────────────────────────────────
+# All targets connect to the remote VM over SSH and run commands inside the
+# restorate-db Docker container.
+
+## db-backup: Dump the database to ./backups/restorate_<timestamp>.dump (custom format).
+##            Backups are portable across Postgres minor versions via pg_restore.
+db-backup:
+	@mkdir -p $(BACKUP_DIR)
+	@TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
+	 OUTFILE=$(BACKUP_DIR)/restorate_$$TIMESTAMP.dump; \
+	 echo "Backing up to $$OUTFILE ..."; \
+	 $(SSH) "docker exec $(DB_CONTAINER) pg_dump -U $(DB_USER) -Fc $(DB_NAME)" > $$OUTFILE; \
+	 echo "Done — $$(du -sh $$OUTFILE | cut -f1)"
+
+## db-restore FILE=<path>: Restore a dump created by db-backup.
+##   Example: make db-restore FILE=backups/restorate_20260402_120000.dump
+##   WARNING: This runs with --clean so existing data is dropped before restore.
+db-restore:
+	@test -n "$(FILE)" || { echo "Usage: make db-restore FILE=<path/to/dump>"; exit 1; }
+	@test -f "$(FILE)" || { echo "File not found: $(FILE)"; exit 1; }
+	@echo "Restoring $(FILE) into $(DB_NAME) on $(SSH_HOST) ..."
+	$(SSH) "docker exec -i $(DB_CONTAINER) pg_restore -U $(DB_USER) -d $(DB_NAME) --clean --if-exists --no-owner" < $(FILE)
+	@echo "Done. Restarting API to re-run migrations ..."
+	$(SSH) "cd $(APP_DIR) && docker compose restart api"
+
+## db-clean: Drop and recreate the public schema — wipes all application tables.
+##           The API auto-migrates the schema on next startup.
+##           Use this for a fresh-state deploy without recreating the Postgres container.
+db-clean:
+	@echo "WARNING: This will wipe all data in $(DB_NAME). Press Ctrl-C within 5 seconds to abort."
+	@sleep 5
+	$(SSH) "docker exec $(DB_CONTAINER) psql -U $(DB_USER) -d $(DB_NAME) \
+	        -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO $(DB_USER);'"
+	@echo "Schema wiped. Restarting API to re-run auto-migration ..."
+	$(SSH) "cd $(APP_DIR) && docker compose restart api"
+
+## db-shell: Open an interactive psql session on the remote database.
+db-shell:
+	$(SSH_TTY) "docker exec -it $(DB_CONTAINER) psql -U $(DB_USER) $(DB_NAME)"
+
+## db-logs: Tail PostgreSQL container logs.
+db-logs:
+	$(SSH_TTY) "docker logs -f --tail=100 $(DB_CONTAINER)"
+
+## db-psql-exec SQL="<query>": Run a one-shot SQL statement (no TTY needed, good for scripts).
+##   Example: make db-psql-exec SQL="SELECT count(*) FROM users"
+db-psql-exec:
+	@test -n "$(SQL)" || { echo "Usage: make db-psql-exec SQL=\"<query>\""; exit 1; }
+	$(SSH) "docker exec $(DB_CONTAINER) psql -U $(DB_USER) -d $(DB_NAME) -c '$(SQL)'"

--- a/compute/restorate_vm/Makefile
+++ b/compute/restorate_vm/Makefile
@@ -2,15 +2,17 @@
         db-backup db-restore db-clean db-shell db-logs db-psql-exec
 
 # ── SSH / container config ────────────────────────────────────────────────────
-SSH_KEY  := ~/.ssh/id_ed25519
-SSH_HOST := debian@192.168.1.203
-SSH      := ssh -i $(SSH_KEY) -o StrictHostKeyChecking=no $(SSH_HOST)
-SSH_TTY  := ssh -t -i $(SSH_KEY) -o StrictHostKeyChecking=no $(SSH_HOST)
+# Defaults match group_vars/all/vars.yml; override on the command line as needed:
+#   make db-shell SSH_HOST=debian@1.2.3.4 DB_NAME=mydb
+SSH_KEY  ?= ~/.ssh/id_ed25519
+SSH_HOST ?= debian@192.168.1.203
+SSH      := ssh -i $(SSH_KEY) -o StrictHostKeyChecking=accept-new $(SSH_HOST)
+SSH_TTY  := ssh -t -i $(SSH_KEY) -o StrictHostKeyChecking=accept-new $(SSH_HOST)
 
-DB_CONTAINER := restorate-db
-DB_NAME      := restorate
-DB_USER      := restorate
-APP_DIR      := /opt/restorate
+DB_CONTAINER ?= restorate-db
+DB_NAME      ?= restorate
+DB_USER      ?= restorate
+APP_DIR      ?= /opt/restorate
 
 BACKUP_DIR := ./backups
 
@@ -44,12 +46,13 @@ db-backup:
 
 ## db-restore FILE=<path>: Restore a dump created by db-backup.
 ##   Example: make db-restore FILE=backups/restorate_20260402_120000.dump
-##   WARNING: This runs with --clean so existing data is dropped before restore.
+##   WARNING: --clean drops existing objects before restore.
 db-restore:
 	@test -n "$(FILE)" || { echo "Usage: make db-restore FILE=<path/to/dump>"; exit 1; }
 	@test -f "$(FILE)" || { echo "File not found: $(FILE)"; exit 1; }
 	@echo "Restoring $(FILE) into $(DB_NAME) on $(SSH_HOST) ..."
-	$(SSH) "docker exec -i $(DB_CONTAINER) pg_restore -U $(DB_USER) -d $(DB_NAME) --clean --if-exists --no-owner" < $(FILE)
+	$(SSH) "docker exec -i $(DB_CONTAINER) pg_restore -U $(DB_USER) -d $(DB_NAME) \
+	        --clean --if-exists --no-owner --exit-on-error" < $(FILE)
 	@echo "Done. Restarting API to re-run migrations ..."
 	$(SSH) "cd $(APP_DIR) && docker compose restart api"
 
@@ -60,6 +63,7 @@ db-clean:
 	@echo "WARNING: This will wipe all data in $(DB_NAME). Press Ctrl-C within 5 seconds to abort."
 	@sleep 5
 	$(SSH) "docker exec $(DB_CONTAINER) psql -U $(DB_USER) -d $(DB_NAME) \
+	        -v ON_ERROR_STOP=1 -X \
 	        -c 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO $(DB_USER);'"
 	@echo "Schema wiped. Restarting API to re-run auto-migration ..."
 	$(SSH) "cd $(APP_DIR) && docker compose restart api"
@@ -73,7 +77,8 @@ db-logs:
 	$(SSH_TTY) "docker logs -f --tail=100 $(DB_CONTAINER)"
 
 ## db-psql-exec SQL="<query>": Run a one-shot SQL statement (no TTY needed, good for scripts).
+##   Note: intended for simple queries; for complex SQL use db-shell instead.
 ##   Example: make db-psql-exec SQL="SELECT count(*) FROM users"
 db-psql-exec:
 	@test -n "$(SQL)" || { echo "Usage: make db-psql-exec SQL=\"<query>\""; exit 1; }
-	$(SSH) "docker exec $(DB_CONTAINER) psql -U $(DB_USER) -d $(DB_NAME) -c '$(SQL)'"
+	$(SSH) "docker exec $(DB_CONTAINER) psql -U $(DB_USER) -d $(DB_NAME) -v ON_ERROR_STOP=1 -X -c '$(SQL)'"

--- a/compute/restorate_vm/Makefile
+++ b/compute/restorate_vm/Makefile
@@ -41,9 +41,11 @@ db-backup:
 	@set -e; \
 	 TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
 	 OUTFILE=$(BACKUP_DIR)/restorate_$$TIMESTAMP.dump; \
+	 TMPFILE=$$OUTFILE.tmp; \
 	 echo "Backing up to $$OUTFILE ..."; \
-	 $(SSH) "docker exec $(DB_CONTAINER) pg_dump -U $(DB_USER) -Fc $(DB_NAME)" > $$OUTFILE && \
-	 echo "Done — $$(du -sh $$OUTFILE | cut -f1)"
+	 $(SSH) "docker exec $(DB_CONTAINER) pg_dump -U $(DB_USER) -Fc $(DB_NAME)" > $$TMPFILE && \
+	 mv $$TMPFILE $$OUTFILE && \
+	 echo "Done — $$(du -sh $$OUTFILE | cut -f1)" || { rm -f $$TMPFILE; exit 1; }
 
 ## db-restore FILE=<path>: Restore a dump created by db-backup.
 ##   Example: make db-restore FILE=backups/restorate_20260402_120000.dump
@@ -53,7 +55,7 @@ db-restore:
 	@test -f "$(FILE)" || { echo "File not found: $(FILE)"; exit 1; }
 	@echo "Restoring $(FILE) into $(DB_NAME) on $(SSH_HOST) ..."
 	$(SSH) "docker exec -i $(DB_CONTAINER) pg_restore -U $(DB_USER) -d $(DB_NAME) \
-	        --clean --if-exists --no-owner --exit-on-error" < $(FILE)
+	        --clean --if-exists --no-owner --exit-on-error" < "$(FILE)"
 	@echo "Done. Restarting API to re-run migrations ..."
 	$(SSH) "cd $(APP_DIR) && docker compose restart api"
 


### PR DESCRIPTION
## Summary

- `make db-backup` — `pg_dump` custom-format dump to `./backups/restorate_<timestamp>.dump`
- `make db-restore FILE=<path>` — `pg_restore --clean`, restarts API after so auto-migration runs
- `make db-clean` — `DROP SCHEMA public CASCADE` + recreate (fresh-state without wiping the Postgres volume), 5s abort window, restarts API
- `make db-shell` — interactive `psql` via SSH + `docker exec -it`
- `make db-logs` — tail Postgres container logs
- `make db-psql-exec SQL="..."` — one-shot query, scriptable

All targets SSH into `debian@192.168.1.203` and exec into the `restorate-db` container using the existing `~/.ssh/id_ed25519` key.

## Notes

- `db-clean` is the intended path for a fresh deploy without recreating the Postgres container/volume — it wipes all application tables and lets the API's `AutoMigrate` rebuild them on next start
- Backups use Postgres custom format (`-Fc`) — portable across minor versions, supports selective restore
- `db-psql-exec` is intentionally TTY-free so it can be used in scripts/CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)