### PR TITLE
fix: NVMe migration follow-up fixes

### DIFF
--- a/network/grafana/provisioning/alerting/rules.yml
+++ b/network/grafana/provisioning/alerting/rules.yml
@@ -259,7 +259,7 @@ groups:
         for: 5m
         annotations:
           summary: High error rate on Restorate
-          description: "Restorate error rate is {{ printf \"%.1f\" (mulf $values.A.Value 100) }}% (threshold: 5%)"
+          description: "Restorate error rate is {{ if $values.A }}{{ humanizePercentage $values.A.Value }}{{ else }}N/A{{ end }} (threshold: 5%)"
         labels:
           severity: warning
 
@@ -402,7 +402,7 @@ groups:
         for: 5m
         annotations:
           summary: High memory usage on Restorate
-          description: "Restorate RSS is {{ printf \"%.0f\" (divf $values.A.Value 1000000) }}MB (threshold: 500MB)"
+          description: "Restorate RSS is {{ if $values.A }}{{ humanize $values.A.Value }}B{{ else }}N/A{{ end }} (threshold: 500MB)"
         labels:
           severity: warning
 
@@ -503,6 +503,6 @@ groups:
         for: 5m
         annotations:
           summary: High Google Places error ratio on Restorate
-          description: "Google Places error rate is {{ printf \"%.1f\" (mulf $values.A.Value 100) }}% (threshold: 5%)"
+          description: "Google Places error rate is {{ if $values.A }}{{ humanizePercentage $values.A.Value }}{{ else }}N/A{{ end }} (threshold: 5%)"
         labels:
           severity: warning

--- a/network/network-pi-metrics/docker-compose.yml
+++ b/network/network-pi-metrics/docker-compose.yml
@@ -31,11 +31,16 @@ services:
     privileged: true
     command:
       - '-port=9092'
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9092/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
     volumes:
       - /:/rootfs:ro
       - /var/run:/var/run:ro
       - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
+      - /mnt/nvme/docker/:/var/lib/docker:ro
       - /dev/disk/:/dev/disk:ro
 
 volumes:

--- a/network/pihole/docker-compose.yml
+++ b/network/pihole/docker-compose.yml
@@ -26,10 +26,10 @@ services:
       - VIRTUAL_HOST=pihole.mati-lab.online
       - PROXY_LOCATION=/
       - PROXY_SUBDIR=/
-    cap_add: [NET_ADMIN, NET_RAW]
+      - DNSMASQ_USER=root
+    cap_add: [NET_ADMIN, NET_RAW, SETFCAP, CHOWN, SETGID, SETUID, DAC_OVERRIDE]
     cap_drop: [ALL]
     restart: always
-    security_opt: [no-new-privileges:true]
     labels:
       - "com.docker.compose.project=pihole"
       - "com.docker.compose.service=pihole"


### PR DESCRIPTION
## Summary

Follow-up fixes after migrating Docker data root from SD card to NVMe (`/mnt/nvme/docker`).

- **pihole**: Added required Linux capabilities for pihole v6 FTL startup (`SETFCAP`, `CHOWN`, `SETGID`, `SETUID`, `DAC_OVERRIDE`) and `DNSMASQ_USER=root`. Removed `no-new-privileges:true` which blocked startup privilege operations. v6 changed how it handles capabilities vs v5.
- **cadvisor**: Fixed health check hitting wrong port (default 8080 vs configured 9092). Updated Docker volume mount from `/var/lib/docker` to `/mnt/nvme/docker` — the old path no longer exists after migration.
- **grafana**: Fixed 3 alert templates using Sprig math functions (`mulf`/`divf`) that are not available in Grafana 12's template engine. Replaced with `humanizePercentage` and `humanize`. Added nil guards for alerts that fire in NoData state.

## Test plan

- [x] All 19 containers healthy after fixes
- [x] pihole DNS responding (`dig @127.0.0.1 google.com` returns results)
- [x] cadvisor health check passing
- [x] Grafana alert templates no longer producing errors in logs
- [x] Docker data root confirmed on NVMe: `docker info | grep "Docker Root Dir"` → `/mnt/nvme/docker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)