### PR TITLE
fix: remove bridge auth header (secureSettings env var limitation)

### DIFF
--- a/network/grafana-ntfy-bridge/.env.example
+++ b/network/grafana-ntfy-bridge/.env.example
@@ -1,4 +1,2 @@
-# token Grafana sends in Authorization: Bearer header
-AUTH_TOKEN=
 # ntfy bearer token (same secret as NTFY_ALERTS_TOKEN in grafana/.env)
 NTFY_TOKEN=

--- a/network/grafana-ntfy-bridge/docker-compose.yml
+++ b/network/grafana-ntfy-bridge/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     security_opt: [no-new-privileges:true]
     networks: [pihole-net]
     environment:
-      - AUTH_TOKEN=${AUTH_TOKEN}
       - NTFY_URL=http://ntfy:80/
       - NTFY_TOPIC=alerts
       - NTFY_TOKEN=${NTFY_TOKEN}

--- a/network/grafana/provisioning/alerting/contact-points.yml
+++ b/network/grafana/provisioning/alerting/contact-points.yml
@@ -9,9 +9,6 @@ contactPoints:
         settings:
           url: http://grafana-ntfy-bridge:4000/webhook
           httpMethod: POST
-          httpHeaderName1: Authorization
           title: "{{ template \"mati-lab.title\" . }}"
           message: "{{ template \"mati-lab.message\" . }}"
-        secureSettings:
-          httpHeaderValue1: "Bearer ${BRIDGE_AUTH_TOKEN}"
         disableResolveMessage: false


### PR DESCRIPTION
## Summary

- Grafana provisioning's `secureSettings` don't expand `${VAR}` references — the auth header was never being sent, causing 401s on every alert
- The bridge is only reachable within `pihole-net` (internal Docker network), so network isolation is sufficient security
- Remove `AUTH_TOKEN` from bridge compose + env example
- Remove `Authorization` header from Grafana contact point config

## Test plan

- [x] Alert fired → bridge received request → clean ntfy notification delivered

🤖 Generated with [Claude Code](https://claude.com/claude-code)