### PR TITLE
fix(grafana): rename loki-sentinel datasource to loki

### DIFF
--- a/network/grafana/provisioning/alerting/rules.yml
+++ b/network/grafana/provisioning/alerting/rules.yml
@@ -162,7 +162,7 @@ groups:
         condition: C
         data:
           - refId: A
-            datasourceUid: loki-sentinel
+            datasourceUid: loki
             relativeTimeRange:
               from: 600
               to: 0

--- a/network/grafana/provisioning/dashboards/container-logs.json
+++ b/network/grafana/provisioning/dashboards/container-logs.json
@@ -10,7 +10,7 @@
       {
         "name": "container",
         "type": "query",
-        "datasource": "loki-sentinel",
+        "datasource": "loki",
         "query": "label_values(container)",
         "refresh": 2,
         "includeAll": true,
@@ -52,7 +52,7 @@
       "title": "Log Volume",
       "type": "timeseries",
       "gridPos": { "h": 5, "w": 24, "x": 0, "y": 0 },
-      "datasource": "loki-sentinel",
+      "datasource": "loki",
       "targets": [
         {
           "expr": "sum by (container) (count_over_time({container=~\"$container\"} [$__interval]))",
@@ -76,7 +76,7 @@
       "title": "Errors & Warnings",
       "type": "timeseries",
       "gridPos": { "h": 4, "w": 24, "x": 0, "y": 5 },
-      "datasource": "loki-sentinel",
+      "datasource": "loki",
       "targets": [
         {
           "expr": "sum by (container) (count_over_time({container=~\"$container\"} |~ \"(?i)(error|fatal|panic|warn|warning)\" [$__interval]))",
@@ -98,7 +98,7 @@
       "title": "Logs",
       "type": "logs",
       "gridPos": { "h": 18, "w": 24, "x": 0, "y": 9 },
-      "datasource": "loki-sentinel",
+      "datasource": "loki",
       "targets": [
         {
           "expr": "{container=~\"$container\"} |~ \"(?i)$search\" |~ \"(?i)${level:regex}\"",

--- a/network/grafana/provisioning/dashboards/restorate.json
+++ b/network/grafana/provisioning/dashboards/restorate.json
@@ -589,11 +589,11 @@
       "type": "logs",
       "title": "Log Stream",
       "gridPos": { "x": 0, "y": 86, "w": 24, "h": 12 },
-      "datasource": { "type": "loki", "uid": "loki-sentinel" },
+      "datasource": { "type": "loki", "uid": "loki" },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "loki", "uid": "loki-sentinel" },
+          "datasource": { "type": "loki", "uid": "loki" },
           "expr": "{compose_project=\"restorate\"}"
         }
       ],
@@ -611,11 +611,11 @@
       "type": "timeseries",
       "title": "Error Log Count over Time",
       "gridPos": { "x": 0, "y": 98, "w": 12, "h": 8 },
-      "datasource": { "type": "loki", "uid": "loki-sentinel" },
+      "datasource": { "type": "loki", "uid": "loki" },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "loki", "uid": "loki-sentinel" },
+          "datasource": { "type": "loki", "uid": "loki" },
           "expr": "sum(rate({compose_project=\"restorate\"} |= \"error\" [5m]))",
           "legendFormat": "errors/s"
         }
@@ -631,11 +631,11 @@
       "type": "barchart",
       "title": "Log Volume by Level",
       "gridPos": { "x": 12, "y": 98, "w": 12, "h": 8 },
-      "datasource": { "type": "loki", "uid": "loki-sentinel" },
+      "datasource": { "type": "loki", "uid": "loki" },
       "targets": [
         {
           "refId": "A",
-          "datasource": { "type": "loki", "uid": "loki-sentinel" },
+          "datasource": { "type": "loki", "uid": "loki" },
           "expr": "sum by (level) (rate({compose_project=\"restorate\"}[5m]))",
           "legendFormat": "{{level}}"
         }

--- a/network/grafana/provisioning/datasources/loki.yml
+++ b/network/grafana/provisioning/datasources/loki.yml
@@ -1,8 +1,8 @@
 apiVersion: 1
 
 datasources:
-  - name: loki-sentinel
-    uid: loki-sentinel
+  - name: loki
+    uid: loki
     type: loki
     url: http://loki:3100
     access: proxy


### PR DESCRIPTION
## Summary

- Rename Loki datasource from `loki-sentinel` to `loki` — the instance serves all services, not just sentinel-trader
- Updated all references in: datasource config, restorate dashboard, container-logs dashboard, alert rules

## Test plan

- [ ] Restart Grafana to re-provision datasource
- [ ] Verify dashboards load with the new datasource UID
- [ ] Verify container-errors alert rule still fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)