### PR TITLE
chore(network): upgrade Loki 3.5.0 → 3.7.1

### DIFF
--- a/network/loki/docker-compose.yml
+++ b/network/loki/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 
 services:
   loki:
-    image: grafana/loki:3.5.0
+    image: grafana/loki:3.7.1
     container_name: loki
     restart: always
     security_opt: [no-new-privileges:true]


### PR DESCRIPTION
## Summary

- Upgrade Loki from 3.5.0 to 3.7.1
- Fixes `negative structured metadata bytes received` error with newer Promtail versions

## Test plan

- [ ] `make update-loki` on the Pi
- [ ] Verify logs still flow in Grafana
- [ ] Verify error is gone from Loki logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)