### PR TITLE
feat(restorate): support one-time user tag backfill flag

### DIFF
--- a/compute/restorate_lxc/templates/api.env.j2
+++ b/compute/restorate_lxc/templates/api.env.j2
@@ -20,3 +20,6 @@ INVITE_REQUIRED=true
 INVITE_SECRET_PEPPER={{ vault_invite_secret_pepper }}
 ADMIN_KEY={{ vault_admin_key }}
 {% endif %}
+{% if run_user_tag_backfill | default(false) | bool %}
+RUN_USER_TAG_BACKFILL=true
+{% endif %}


### PR DESCRIPTION
## Summary
- Add conditional `RUN_USER_TAG_BACKFILL` env var to `api.env.j2` template
- Triggered via `ansible-playbook playbooks/deploy_app.yml -e "run_user_tag_backfill=true"`
- Subsequent `make deploy` without the flag removes it automatically

## Test plan
- [ ] Deploy with `-e "run_user_tag_backfill=true"` and verify `api.env` contains `RUN_USER_TAG_BACKFILL=true`
- [ ] Deploy again without the flag and verify the var is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)