### PR TITLE
feat: add Grafana Explore Logs plugin

### DIFF
--- a/network/grafana/docker-compose.yml
+++ b/network/grafana/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     container_name: grafana
     restart: always
     security_opt: [no-new-privileges:true]
+    environment:
+      - GF_PLUGINS_PREINSTALL=grafana-clock-panel,grafana-lokiexplore-app
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
## Summary
- Adds `grafana-lokiexplore-app` to `GF_PLUGINS_PREINSTALL` in docker-compose
- Provides a dedicated log browsing UI in Grafana sidebar ("Explore Logs") with auto-field detection, pattern grouping, and per-service coloring

## Deploy
```bash
cd network/grafana && docker compose up -d
```

**Note**: The `environment` block overrides `GF_PLUGINS_PREINSTALL` from `.env`. After deploy, either remove that line from `.env` or update it to match: `grafana-clock-panel,grafana-lokiexplore-app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)