### PR TITLE
fix(network-pi): enforce ethernet-only netplan; disable wifi

### DIFF
--- a/network/ansible/playbooks/configure.yml
+++ b/network/ansible/playbooks/configure.yml
@@ -68,15 +68,25 @@
     # ── Network: ethernet only, no wifi ────────────────────────────────────
     # Why: the Pi's eth0 and wlan0 were both grabbing DHCP leases on the same
     # LAN, triggering router "duplicate IP" alerts (one hostname, two leases).
-    # We enforce an ethernet-only netplan and disable cloud-init network
-    # regeneration so the config survives reboots and re-images.
+    # We enforce an ethernet-only netplan in a dedicated file (so cloud-init's
+    # 50-cloud-init.yaml is removed rather than repurposed) and disable
+    # cloud-init network regeneration so the config survives reboots/re-images.
     - name: Write ethernet-only netplan
       ansible.builtin.template:
         src: ../templates/netplan-ethernet.yaml.j2
-        dest: /etc/netplan/50-cloud-init.yaml
+        dest: /etc/netplan/01-ethernet.yaml
+        # 0600 is netplan-enforced — 0106+ warns on anything group/world readable
+        # ("too open") even if the file contains no secrets. Keep it strict.
         mode: "0600"
         owner: root
         group: root
+      notify: Apply netplan
+      tags: [base, network]
+
+    - name: Remove cloud-init netplan file (our 01-ethernet.yaml is authoritative)
+      ansible.builtin.file:
+        path: /etc/netplan/50-cloud-init.yaml
+        state: absent
       notify: Apply netplan
       tags: [base, network]
 
@@ -311,6 +321,16 @@
         name: systemd-resolved
         state: restarted
 
+    # `netplan apply` can momentarily drop the SSH session when links flap.
+    # Fire-and-forget, then wait for the connection to come back so the play
+    # doesn't fail on a transient disconnect.
     - name: Apply netplan
       ansible.builtin.command: netplan apply
+      async: 120
+      poll: 0
       changed_when: true
+
+    - name: Wait for connection after netplan apply
+      ansible.builtin.wait_for_connection:
+        timeout: 120
+        delay: 2

--- a/network/ansible/playbooks/configure.yml
+++ b/network/ansible/playbooks/configure.yml
@@ -65,6 +65,30 @@
       notify: Restart systemd-resolved
       tags: [base, dns]
 
+    # ── Network: ethernet only, no wifi ────────────────────────────────────
+    # Why: the Pi's eth0 and wlan0 were both grabbing DHCP leases on the same
+    # LAN, triggering router "duplicate IP" alerts (one hostname, two leases).
+    # We enforce an ethernet-only netplan and disable cloud-init network
+    # regeneration so the config survives reboots and re-images.
+    - name: Write ethernet-only netplan
+      ansible.builtin.template:
+        src: ../templates/netplan-ethernet.yaml.j2
+        dest: /etc/netplan/50-cloud-init.yaml
+        mode: "0600"
+        owner: root
+        group: root
+      notify: Apply netplan
+      tags: [base, network]
+
+    - name: Disable cloud-init network regeneration
+      ansible.builtin.template:
+        src: ../templates/cloud-init-disable-network.cfg.j2
+        dest: /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg
+        mode: "0644"
+        owner: root
+        group: root
+      tags: [base, network]
+
     # ── NVMe data drive ────────────────────────────────────────────────────
     - name: Create NVMe mount point
       ansible.builtin.file:
@@ -286,3 +310,7 @@
       ansible.builtin.systemd:
         name: systemd-resolved
         state: restarted
+
+    - name: Apply netplan
+      ansible.builtin.command: netplan apply
+      changed_when: true

--- a/network/ansible/templates/cloud-init-disable-network.cfg.j2
+++ b/network/ansible/templates/cloud-init-disable-network.cfg.j2
@@ -1,0 +1,1 @@
+network: {config: disabled}

--- a/network/ansible/templates/netplan-ethernet.yaml.j2
+++ b/network/ansible/templates/netplan-ethernet.yaml.j2
@@ -1,0 +1,7 @@
+network:
+  version: 2
+  ethernets:
+    eth0:
+      optional: true
+      dhcp4: true
+      dhcp6: true

--- a/network/scripts/manage-grafana.sh
+++ b/network/scripts/manage-grafana.sh
@@ -46,8 +46,9 @@ import_dashboard() {
   scp "${SSH_OPTS[@]}" "$payload_file" "$REMOTE:$remote_payload"
   rm -f "$payload_file"
 
-  # shellcheck disable=SC2029  # $remote_payload must expand client-side here
   local response
+  # $remote_payload must expand client-side here; ssh arg is already a single string.
+  # shellcheck disable=SC2029
   response=$(ssh "${SSH_OPTS[@]}" "$REMOTE" "docker run --rm --network pihole-net \
     -v '$remote_payload:/payload.json' \
     curlimages/curl:latest \

--- a/network/scripts/manage-grafana.sh
+++ b/network/scripts/manage-grafana.sh
@@ -41,10 +41,12 @@ import_dashboard() {
   jq '{dashboard: (. | .id = null), overwrite: true}' "$json_file" > "$payload_file"
 
   # SCP payload to Pi, then import via docker on pihole-net
-  local remote_payload="/tmp/grafana-import-$(basename "$json_file")"
+  local remote_payload
+  remote_payload="/tmp/grafana-import-$(basename "$json_file")"
   scp "${SSH_OPTS[@]}" "$payload_file" "$REMOTE:$remote_payload"
   rm -f "$payload_file"
 
+  # shellcheck disable=SC2029  # $remote_payload must expand client-side here
   local response
   response=$(ssh "${SSH_OPTS[@]}" "$REMOTE" "docker run --rm --network pihole-net \
     -v '$remote_payload:/payload.json' \


### PR DESCRIPTION
## Summary

- Ansible now writes an ethernet-only netplan + a cloud-init override that disables network regeneration on boot.
- Fresh re-images of the network Pi won't surface a \`wlan0\` DHCP lease even if Raspberry Pi Imager leaked wifi credentials during flashing.

## Why

After re-imaging the Pi to Ubuntu 24.04 LTS, the router started firing \"duplicate IP\" alerts. Root cause: both \`eth0\` and \`wlan0\` were up and grabbing DHCP leases on the same LAN (.252 + .253 on the same hostname), which the router treats as a conflict. Imager's advanced-options dialog had retained wifi credentials from an earlier flash, so cloud-init shipped a \`wifis:\` block in \`50-cloud-init.yaml\`.

Already applied live on the Pi: \`wlan0\` is DOWN, \`eth0\` keeps .252, \`netplan-wpa-wlan0.service\` inactive.

## Test plan

- [x] Applied live on the Pi; \`ip -br addr\` shows \`wlan0 DOWN\` with no IP.
- [x] \`netplan generate && netplan apply\` succeeded without errors.
- [x] \`/etc/cloud/cloud.cfg.d/99-disable-network-config.cfg\` present so cloud-init doesn't rewrite netplan on boot.
- [ ] Next re-image or running \`make configure\` should produce an identical state with no manual steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)